### PR TITLE
(platform/Posix) Fix bug: infinite loop on 32 bits posix systems

### DIFF
--- a/platform/posix/shm.c
+++ b/platform/posix/shm.c
@@ -32,7 +32,7 @@ char* arcan_findshmkey(int* dfd, bool semalloc){
 	int retrycount = 10;
 	size_t pb_ofs = 0;
 
-	const char* pattern = "/arcan_%i_%im";
+	const char pattern[] = "/arcan_%i_%im";
 	char playbuf[sizeof(pattern) + 8];
 
 	while (1){


### PR DESCRIPTION
We were wrongly using sizeof() to get the size of a (char *).
This would return the size of the pointer instead of the size of the
string (8 on x86_64, 4 on x86).

The obtained size was then used to allocate a second buffer. That buffer
ended up being too small on x86 platforms, causing the following snprintf()
call to truncate its result and shm_open() to fail, which would cause an
infinite loop.
