### PR TITLE
(tools/vrbridge) fix linking against shmif

### DIFF
--- a/src/tools/vrbridge/CMakeLists.txt
+++ b/src/tools/vrbridge/CMakeLists.txt
@@ -10,29 +10,30 @@ set(ARCAN_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../)
 set(CMAKE_MODULE_PATH ${ARCAN_ROOT_DIR}/src/platform/cmake/modules)
 
 include(FindPkgConfig)
-pkg_check_modules(ARCAN_SHMIF arcan-shmif)
+if (ARCAN_SOURCE_DIR)
+	add_subdirectory(${ARCAN_SOURCE_DIR}/shmif ashmif)
+else()
+	find_package(arcan_shmif REQUIRED)
+endif()
 
 add_definitions(
-	-Wall
 	-D__UNIX
 	-DPOSIX_C_SOURCE
 	-DGNU_SOURCE
-  -Wno-unused-const-variable
+	-Wall
+	-Wno-unused-const-variable
 	-Wno-unused-function
-	-std=gnu11 # shmif-api requires this
 )
 
 include_directories(
-	${ARCAN_SHMIF_INCLUDE_DIRS}
+	${ARCAN_SHMIF_INCLUDE_DIR}
 	${ARCAN_ROOT_DIR}/src/engine
-	${ARCAN_ROOT_DIR}/src/shmif
-	${ARCAN_ROOT_DIR}/external
 )
 
 SET(LIBRARIES
 	pthread
 	m
-	${ARCAN_SHMIF_LIBRARIES}
+	${ARCAN_SHMIF_LIBRARY}
 )
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")


### PR DESCRIPTION
Without this, compilation fails with:
```
[ 75%] Linking C executable arcan_vr
/usr/bin/ld: CMakeFiles/arcan_vr.dir/vrbridge.c.o: in function `main':
vrbridge.c:(.text.startup+0x4b): undefined reference to `arcan_shmif_open'
/usr/bin/ld: vrbridge.c:(.text.startup+0x65): undefined reference to `arcan_shmif_setprimary'
/usr/bin/ld: vrbridge.c:(.text.startup+0x103): undefined reference to `arcan_shmif_resize_ext'
/usr/bin/ld: vrbridge.c:(.text.startup+0x115): undefined reference to `arcan_shmif_substruct'
/usr/bin/ld: vrbridge.c:(.text.startup+0x14c): undefined reference to `arg_lookup'
/usr/bin/ld: vrbridge.c:(.text.startup+0x16a): undefined reference to `arg_lookup'
/usr/bin/ld: vrbridge.c:(.text.startup+0x230): undefined reference to `arcan_shmif_wait'
/usr/bin/ld: vrbridge.c:(.text.startup+0x2f9): undefined reference to `arg_lookup'
/usr/bin/ld: vrbridge.c:(.text.startup+0x35f): undefined reference to `arcan_shmif_drop'
/usr/bin/ld: vrbridge.c:(.text.startup+0x3a3): undefined reference to `arcan_shmif_drop'
/usr/bin/ld: CMakeFiles/arcan_vr.dir/openhmd.c.o: in function `openhmd_init':
openhmd.c:(.text+0x2d9): undefined reference to `arg_lookup'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/arcan_vr.dir/build.make:176: arcan_vr] Error 1
```