### PR TITLE
Improve error message when appl can't be loaded

### DIFF
--- a/src/engine/arcan_main.c
+++ b/src/engine/arcan_main.c
@@ -230,7 +230,7 @@ static void override_resspaces(const char* respath)
 
  void appl_user_warning(const char* name, const char* err_msg)
 {
-	arcan_warning("\x1b[1mCouldn't load application (\x1b[33m%s\x1b[39m)\n",
+	arcan_warning("\x1b[1mCouldn't load application \x1b[33m(%s): \x1b[31m%s\x1b[39m\n",
 		name, err_msg);
 
 	if (!name || !strlen(name))


### PR DESCRIPTION
`arcan_verifyload_appl` generates an error message but it never gets printed, so this patch adds it to the message in `appl_user_warning`.