### PR TITLE
(build) unbreak -GNinja

### DIFF
--- a/src/shmif/CMakeLists.txt
+++ b/src/shmif/CMakeLists.txt
@@ -261,7 +261,7 @@ set_target_properties(arcan_shmif_ext PROPERTIES
 
 set_target_properties(arcan_shmif_intext PROPERTIES
 	COMPILE_FLAGS "-fPIC -DHEADLESS_NOARCAN"
-	OUTPUT_NAME arcan_shmif_ext
+	OUTPUT_NAME arcan_shmif_intext
 	VERSION ${ASHMIF_MAJOR}.${ASHMIF_MINOR}
 )
 


### PR DESCRIPTION
```
$ cmake -GNinja /path/to/arcan/src
$ ninja
ninja: error: build.ninja:1320: multiple rules generate shmif/libarcan_shmif_ext.so.0.13 [-w dupbuild=err]

$ cat -n build.ninja
  1048	build shmif/libarcan_shmif_ext.so.0.13: C_SHARED_LIBRARY_LINKER__arcan_shmif_ext shmif/CMakeFiles/arcan_shmif_ext.dir/egl-dri-rnode/egl-dri-rnode.c.o shmif/CMakeFiles/arcan_shmif_ext.dir/__/platform/agp/glshared.c.o shmif/CMakeFiles/arcan_shmif_ext.dir/__/platform/agp/shdrmgmt.c.o shmif/CMakeFiles/arcan_shmif_ext.dir/__/platform/agp/glinit.c.o shmif/CMakeFiles/arcan_shmif_ext.dir/__/platform/agp/gl21.c.o shmif/CMakeFiles/arcan_shmif_ext.dir/__/platform/posix/mem.c.o | /usr/local/lib/libEGL.so /usr/local/lib/libdrm.so /usr/local/lib/libgbm.so /usr/local/lib/libxkbcommon.so /usr/local/lib/libGL.so shmif/libarcan_shmif.so.0.13 /usr/lib/libm.so /usr/lib/librt.so /usr/lib/libdl.so || shmif/libarcan_shmif.so
  1049	  LINK_LIBRARIES = -Wl,-rpath,/usr/local/lib:/tmp/foo/shmif: /usr/local/lib/libEGL.so /usr/local/lib/libdrm.so /usr/local/lib/libgbm.so /usr/local/lib/libxkbcommon.so /usr/local/lib/libGL.so shmif/libarcan_shmif.so.0.13 -lm -pthread -lrt -ldl
  1050	  OBJECT_DIR = shmif/CMakeFiles/arcan_shmif_ext.dir
  1051	  POST_BUILD = :
  1052	  PRE_LINK = :
  1053	  SONAME = libarcan_shmif_ext.so.0.13
  1054	  SONAME_FLAG = -Wl,-soname,
  1055	  TARGET_COMPILE_PDB = shmif/CMakeFiles/arcan_shmif_ext.dir/
  1056	  TARGET_FILE = shmif/libarcan_shmif_ext.so.0.13
  1057	  TARGET_PDB = shmif/libarcan_shmif_ext.pdb
[...]
  1310	build shmif/libarcan_shmif_ext.so.0.13: C_SHARED_LIBRARY_LINKER__arcan_shmif_intext shmif/CMakeFiles/arcan_shmif_intext.dir/egl-dri-rnode/egl-dri-rnode.c.o shmif/CMakeFiles/arcan_shmif_intext.dir/__/platform/agp/glshared.c.o shmif/CMakeFiles/arcan_shmif_intext.dir/__/platform/agp/shdrmgmt.c.o shmif/CMakeFiles/arcan_shmif_intext.dir/__/platform/agp/glinit.c.o shmif/CMakeFiles/arcan_shmif_intext.dir/__/platform/agp/gl21.c.o shmif/CMakeFiles/arcan_shmif_intext.dir/__/platform/posix/mem.c.o | /usr/local/lib/libGL.so /usr/local/lib/libEGL.so /usr/local/lib/libdrm.so /usr/local/lib/libgbm.so /usr/local/lib/libxkbcommon.so shmif/libarcan_shmif.so.0.13 /usr/lib/libm.so /usr/lib/librt.so /usr/lib/libdl.so || shmif/libarcan_shmif.so
  1311	  LINK_LIBRARIES = -Wl,-rpath,/usr/local/lib:/tmp/foo/shmif: /usr/local/lib/libGL.so /usr/local/lib/libEGL.so /usr/local/lib/libdrm.so /usr/local/lib/libgbm.so /usr/local/lib/libxkbcommon.so shmif/libarcan_shmif.so.0.13 -lm -pthread -lrt -ldl
  1312	  OBJECT_DIR = shmif/CMakeFiles/arcan_shmif_intext.dir
  1313	  POST_BUILD = :
  1314	  PRE_LINK = :
  1315	  SONAME = libarcan_shmif_ext.so.0.13
  1316	  SONAME_FLAG = -Wl,-soname,
  1317	  TARGET_COMPILE_PDB = shmif/CMakeFiles/arcan_shmif_intext.dir/
  1318	  TARGET_FILE = shmif/libarcan_shmif_ext.so.0.13
  1319	  TARGET_PDB = shmif/libarcan_shmif_ext.pdb
```
