### PR TITLE
(build) unbreak Wayland on FreeBSD

### DIFF
--- a/src/wayland/CMakeLists.txt
+++ b/src/wayland/CMakeLists.txt
@@ -69,10 +69,11 @@ endforeach()
 
 set_source_files_properties(${sources} PROPERTIES GENERATED ON)
 add_library(wlprot STATIC ${sources})
+target_include_directories(wlprot PRIVATE ${WAYLAND_SERVER_INCLUDE_DIRS})
 
 SET(WAYBRIDGE_LIBRARIES
 	${STDLIB}
-	EGL
+	${EGL_LIBRARIES}
 	arcan_shmif_int
 	arcan_shmif_intext
 	${WAYLAND_SERVER_LIBRARIES}


### PR DESCRIPTION
```
$ cmake -GNinja /path/to/arcan/src
$ ninja
[16/219] Building C object wayland/CMakeFiles/wlprot.dir/wayland-xdg-shell-unstable-v6-protocol.c.o
FAILED: wayland/CMakeFiles/wlprot.dir/wayland-xdg-shell-unstable-v6-protocol.c.o
/usr/bin/cc -DCLOCK_MONOTONIC_RAW=CLOCK_REALTIME_FAST -DLIBUSB_BSD -DOPENGL -DPLATFORM_HEADER=\"/path/to/arcan/src/platform/platform.h\" -D_WITH_DPRINTF_ -D__BSD -D__UNIX  -Wall -Wno-unknown-warning-option -Wno-unused-const-variable -Wno-unused-value -Wno-missing-braces -Wno-unused-function -Wno-atomic-alignment -Wno-unused-variable -Wno-macro-redefined -std=gnu11 -MD -MT wayland/CMakeFiles/wlprot.dir/wayland-xdg-shell-unstable-v6-protocol.c.o -MF wayland/CMakeFiles/wlprot.dir/wayland-xdg-shell-unstable-v6-protocol.c.o.d -o wayland/CMakeFiles/wlprot.dir/wayland-xdg-shell-unstable-v6-protocol.c.o   -c wayland/wayland-xdg-shell-unstable-v6-protocol.c
wayland/wayland-xdg-shell-unstable-v6-protocol.c:31:10: fatal error: 'wayland-util.h' file not found
#include "wayland-util.h"
         ^~~~~~~~~~~~~~~~
1 error generated.
[207/219] Linking C executable arcan-wayland
FAILED: arcan-wayland
: && /usr/bin/cc    wayland/CMakeFiles/arcan-wayland.dir/waybridge.c.o  -o arcan-wayland  -Wl,-rpath,/tmp/foo/shmif:/usr/local/lib: -lEGL shmif/libarcan_shmif.a shmif/libarcan_shmif_intext.so.0.13 /usr/local/lib/libwayland-server.so /usr/local/lib/libxkbcommon.so wayland/libwlprot.a -lm -pthread -lrt -ldl && :
ld: error: unable to find library -lEGL
```
