### PR TITLE
(build) Advertise LuaJIT in --version

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -416,7 +416,7 @@ else()
 	set(LUA_LINKTYPE "dynamic")
 
 	if (NOT DISABLE_JIT)
-		set(LUA51_JIT ON)
+		set(LUA_TAG "luajit51")
 		if (EXISTS ${EXTERNAL_SRC_DIR}/git/luajit)
 			ExternalProject_Add(luajit
 				SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/luajit
@@ -444,6 +444,7 @@ else()
 	endif()
 
 	if (NOT LUA_LIBRARY OR DISABLE_JIT)
+		set(LUA_TAG "lua51")
 		if (NOT BUILTIN_LUA)
 			find_package(Lua51 REQUIRED)
 		else()
@@ -536,14 +537,6 @@ else()
 			set_property(SOURCE engine/arcan_math_simd.c
 				APPEND PROPERTY COMPILE_FLAGS -msse3)
 		endif()
-	endif()
-
-	if (LUA51_JIT)
-		set_property(SOURCE engine/arcan_lua.c APPEND PROPERTY
-			COMPILE_DEFINITIONS LUA51_JIT)
-		set(LUA_TAG "luajit51")
-	else()
-		set(LUA_TAG "lua51")
 	endif()
 
 	# can we get sane literal concatenation one day?

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -416,6 +416,7 @@ else()
 	set(LUA_LINKTYPE "dynamic")
 
 	if (NOT DISABLE_JIT)
+		set(LUA51_JIT ON)
 		if (EXISTS ${EXTERNAL_SRC_DIR}/git/luajit)
 			ExternalProject_Add(luajit
 				SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/luajit
@@ -431,7 +432,6 @@ else()
 			)
 			set(LUA_LIBRARY "${CMAKE_CURRENT_BINARY_DIR}/luajit/src/libluajit.a")
 			set(LUA_LIBRARIES ${LUA_LIBRARY})
-			set(LUA51_JIT ON)
 			set(LUA_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/luajit/src")
 			list(APPEND MAIN_DEPS luajit)
 			set(LUA_LINKTYPE "static")
@@ -452,7 +452,6 @@ else()
 			set(LUA_LIBRARIES lua51)
 			set(LUA_LINKTYPE "static")
 		endif()
-		set(LUA51_JIT OFF)
 	endif()
 
 	LIST (APPEND

--- a/src/engine/arcan_lua.c
+++ b/src/engine/arcan_lua.c
@@ -65,12 +65,6 @@
 
 #include <poll.h>
 
-#ifdef LUA51_JIT
-#include <luajit.h>
-#else
-
-#endif
-
 #if LUA_VERSION_NUM == 501
 	#define lua_rawlen(x, y) lua_objlen(x, y)
 #endif


### PR DESCRIPTION
```
$ pkg info arcan | fgrep -i jit
        LUAJIT         : on
        libluajit-5.1.so.2
```
vs.
```
$ arcan --version
Xorg running, switching to arcan_sdl
0.6.0-egl-dri-gl21-openal-evdev-lua51-unknown-FreeBSD
shmif-9223310550170255392
luaapi-0:11
```
