### PR TITLE
Explicitly specifies docgen input file encoding

### DIFF
--- a/doc/docgen.rb
+++ b/doc/docgen.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/ruby
 require 'fileutils'
 
+Encoding.default_external = Encoding::UTF_8
+
 def scangrp(inf)
 	line = ""
 	res = {}


### PR DESCRIPTION
In some cases system locale configuration messes up file reading operations by using encoding that isn't UTF-8.

Explicitly requires UTF-8 encoding for read operations.