### PR TITLE
(CI) Update FreeBSD image to 13.0

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,4 +1,4 @@
-name: FreeBSD 12.2 amd64
+name: FreeBSD 13.0 amd64
 
 on: [ push, pull_request ]
 
@@ -7,8 +7,8 @@ jobs:
     runs-on: macos-latest # until https://github.com/actions/runner/issues/385
     steps:
     - uses: actions/checkout@v2
-    - name: test
-      uses: vmactions/freebsd-vm@v0.0.9 # on update bump workflow name
+    - name: Test in FreeBSD VM
+      uses: vmactions/freebsd-vm@v0.1.5 # on update bump workflow name
       with:
         prepare: |
           pkg install -y cmake ninja pkgconf # build


### PR DESCRIPTION
FreeBSD 13.0 brings [memfd_create(3)](https://man.freebsd.org/memfd_create/3), native [eventfd(2)](https://man.freebsd.org/eventfd/2), [copy_file_range(2)](https://man.freebsd.org/copy_file_range/2), [qsort_s(3)](https://man.freebsd.org/qsort_s/3), [cap_net(3)](https://man.freebsd.org/cap_net/3), etc.