### PR TITLE
(doc) missing endif in target_seek

### DIFF
--- a/doc/target_seek.lua
+++ b/doc/target_seek.lua
@@ -54,3 +54,4 @@ end
 #ifdef ERROR
 	target_seek(BADID)
 end
+#endif


### PR DESCRIPTION
The file `doc/target_seek.lua` has a missing `#endif`, resulting in some warnings while running `docgen.rb`.