### PR TITLE
(CI) unbreak FreeBSD build

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -4,15 +4,15 @@ on: [ push, pull_request ]
 
 jobs:
   build-everything:
-    runs-on: macos-latest # until https://github.com/actions/runner/issues/385
+    runs-on: macos-10.15 # until https://github.com/actions/runner/issues/385
     steps:
     - uses: actions/checkout@v2
     - name: Test in FreeBSD VM
-      uses: vmactions/freebsd-vm@v0.1.5 # on update bump workflow name
+      uses: vmactions/freebsd-vm@v0.1.6 # on update bump workflow name
       with:
         prepare: |
           pkg install -y cmake ninja pkgconf # build
-          pkg install -y freetype2 luajit openal-soft sqlite3 # common
+          pkg install -y evdev-proto freetype2 luajit openal-soft sqlite3 # common
           pkg install -y -x '^mesa($|-libs)' # egl-dri
           pkg install -y wayland-protocols wayland xcb-util-wm libxkbcommon # wayland
           pkg install -y sdl2 # sdl (hybrid)


### PR DESCRIPTION
Building on FreeBSD got broken by undefined `environ` since 602969bfe43e9 which persisted for a few months but then got obscured by `macos-latest` runners upgrading to a version that doesn't support VirtualBox required by `freebsd-vm` and broken by 3c1674a8f5db due to missing dependency. Since then `environ` was fixed by e7f6eba7ef29, so CI can be green again.

Let's also update `freebsd-vm`. It's still based on FreeBSD 13.0 rather than 13.1.
