### PR TITLE
(CI) upgrade FreeBSD version to avoid future breakage

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,4 +1,4 @@
-name: FreeBSD 13.0 amd64
+name: FreeBSD 13.1 amd64
 
 on: [ push, pull_request ]
 
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Test in FreeBSD VM
-      uses: vmactions/freebsd-vm@v0.1.6 # on update bump workflow name
+      uses: vmactions/freebsd-vm@v0.1.7 # on update bump workflow name
       with:
         prepare: |
           pkg install -y cmake ninja pkgconf # build


### PR DESCRIPTION
FreeBSD Project currently doesn't keep recent binary packages for EOL versions. `/release_0` packages (non-default) frozen at 13.0 release (2021-04-13) will remain after 13.0 EOL (2022-08-31) for 13.* branch lifetime (until 2026-01-31) but maybe too old for arcan CI.