### PR TITLE
(build) unbreak manpage installation in src/tools/

### DIFF
--- a/src/tools/acfgfs/CMakeLists.txt
+++ b/src/tools/acfgfs/CMakeLists.txt
@@ -14,6 +14,8 @@ find_package(RT REQUIRED)
 find_package(Threads REQUIRED)
 find_package(DL REQUIRED)
 
+include(GNUInstallDirs) # CMAKE_INSTALL_MANDIR
+
 add_definitions(
 	-Wall
 	-D__UNIX

--- a/src/tools/aclip/CMakeLists.txt
+++ b/src/tools/aclip/CMakeLists.txt
@@ -17,6 +17,8 @@ find_package(RT REQUIRED)
 find_package(Threads REQUIRED)
 find_package(DL REQUIRED)
 
+include(GNUInstallDirs) # CMAKE_INSTALL_MANDIR
+
 add_definitions(
 	-Wall
 	-D__UNIX

--- a/src/tools/aloadimage/CMakeLists.txt
+++ b/src/tools/aloadimage/CMakeLists.txt
@@ -19,6 +19,8 @@ find_package(DL REQUIRED)
 find_package(Threads REQUIRED)
 find_package(Sanitizers REQUIRED)
 
+include(GNUInstallDirs) # CMAKE_INSTALL_MANDIR
+
 SET(LIBRARIES
 	Math::Math
 	RT::RT


### PR DESCRIPTION
Regressed by #250. CC @AndersonTorres

`CMAKE_INSTALL_BINDIR` is not affected due to [hardcoded fallback](https://github.com/Kitware/CMake/blob/v3.23.2/Source/cmInstallCommand.cxx#L2262) using relative rather than absolute path.