### PR TITLE
(CI) Add DragonFly BSD job

### DIFF
--- a/.github/workflows/dragonfly.yml
+++ b/.github/workflows/dragonfly.yml
@@ -1,0 +1,24 @@
+name: DragonFly
+
+on: [ push, pull_request ]
+
+jobs:
+  build-everything:
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test in DragonFly VM
+      uses: vmactions/dragonflybsd-vm@v0
+      with:
+        prepare: |
+          pkg install -y cmake ninja pkgconf # build
+          pkg install -y evdev-proto freetype2 luajit openal-soft sqlite3 # common
+          pkg install -y -x '^mesa($|-libs)' # egl-dri
+          pkg install -y wayland-protocols wayland xcb-util-wm libxkbcommon # wayland
+          pkg install -y sdl2 # sdl (hybrid)
+          pkg install -y espeak vlc # decode
+          pkg install -y ffmpeg libvncserver tesseract # encode
+        run: |
+          cmake -B _build -G Ninja -S src -DBUILD_PRESET:STRING="everything"
+          cmake --build _build
+          cmake --install _build


### PR DESCRIPTION
Arcan is packaged on DragonFly (DPorts is based on FreeBSD Ports), so this would help downstream. Mainly to validate platform-specific code: evdev support, psep_open.c, random.c.

https://github.com/DragonFlyBSD/DeltaPorts/tree/master/ports/multimedia/arcan
https://sting.dragonflybsd.org/dports/logs/multimedia___arcan.log
