### PR TITLE
Breaks out OpenAL from arcan_audio.c into platform/audio/openal.c

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,6 +141,7 @@ else()
 		endif()
 		include(GNUInstallDirs)
 	endif()
+	set(APLATFORM_STR "openal")
 	set(AGPPLATFORM_STR "gl21, gles2, gles3, stub")
 
 	# we can remove some of this cruft when 'buntu LTS gets ~3.0ish
@@ -161,6 +162,7 @@ else()
 	amsg("${CL_YEL}\t-DBUILD_PRESET=${CL_GRN}everything client${CL_RST}")
 	amsg("")
 	amsg("${CL_WHT}Audio/Video/Input Support:")
+	amsg("${CL_YEL}\t-DAUDIO_PLATFORM=${CL_GRN}${APLATFORM_STR}${CL_RST}")
 	amsg("${CL_YEL}\t-DVIDEO_PLATFORM=${CL_GRN}${VPLATFORM_STR}${CL_RST}")
 	amsg("${CL_YEL}\t-DAGP_PLATFORM=${CL_GRN}${AGPPLATFORM_STR}${CL_RST}")
 	amsg("")
@@ -317,36 +319,6 @@ else()
 	set(FREETYPE_DEFAULT_LIBRARIES ${FREETYPE_LIBRARIES})
 	set(FREETYPE_DEFAULT_INCLUDE_DIRS ${FREETYPE_INCLUDE_DIRS})
 
-	# need the separation here to not confuse openAL here with
-	# the version that we patch into LWA
-	if (EXISTS ${EXTERNAL_SRC_DIR}/git/openal AND STATIC_OPENAL)
-		amsg("${CL_YEL}Building OpenAL static from external/git mirror${CL_RST}")
-		ExternalProject_Add(OpenAL
-			SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/openal
-			BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/openal_static
-			UPDATE_COMMAND ""
-			GIT_REPOSITORY "${EXTERNAL_SRC_DIR}/git/openal"
-			${EXTERNAL_DEFS}
-			${CMAKE_EXTERNAL_DEFS}
-			-DALSOFT_BACKEND_DSOUND=OFF
-			-DALSOFT_BACKEND_MMDEVAPI=OFF
-			-DALSOFT_BACKEND_OPENSL=OFF
-			-DALSOFT_BACKEND_PORTAUDIO=OFF
-			-DALSOFT_BACKEND_SOLARIS=OFF
-			-DALSOFT_BACKEND_SNDIO=OFF
-			-DALSOFT_BACKEND_QSA=OFF
-			-DALSOFT_BACKEND_WAVE=OFF
-			-DALSOFT_BACKEND_WINMM=OFF
-		)
-		set(OPENAL_LIBRARY
-			"${CMAKE_CURRENT_BINARY_DIR}/openal_static/libopenal.a"
-		)
-		set(OPENAL_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/include/AL")
-		list(APPEND MAIN_DEPS OpenAL)
-	else()
-		find_package(OpenAL REQUIRED QUIET)
-	endif()
-
 	#
 	# the amalgamation is already included in the external/ tree sqlite3 use is
 	# primarily settings management and very limited amount of queries, size is
@@ -364,6 +336,7 @@ else()
 
 	include(${PLATFORM_ROOT}/cmake/CMakeLists.AGP)
 	include(${PLATFORM_ROOT}/cmake/CMakeLists.Video)
+	include(${PLATFORM_ROOT}/cmake/CMakeLists.Audio)
 	set(EXTMAKE_CMD make)
 
 	# for the statically- linked external dependencies, we need to hint where
@@ -426,7 +399,6 @@ else()
 		INCLUDE_DIRS
 		${LUA_INCLUDE_DIR}
 		${LUA_INCLUDE_DIRS}
-		${OPENAL_INCLUDE_DIR}
 		${FREETYPE_DEFAULT_INCLUDE_DIRS}
 		${SQLite3_INCLUDE_DIR}
 		${CMAKE_CURRENT_SOURCE_DIR}/platform
@@ -594,6 +566,7 @@ else()
 		${AGP_SOURCES}
 	 	${PLATFORM_SOURCES}
 		${VIDEO_PLATFORM_SOURCES}
+		${AUDIO_PLATFORM_SOURCES}
 		${PLATFORM_ROOT}/${INPUT_PLATFORM}/event.c
 	)
 	add_sanitizers(arcan)
@@ -616,8 +589,8 @@ else()
 		${STDLIB}
 		${ARCAN_LIBRARIES}
 		${VIDEO_LIBRARIES}
+		${AUDIO_LIBRARIES}
 		${AGP_LIBRARIES}
-		${OPENAL_LIBRARY}
 		arcan_shmif_int
 	)
 
@@ -651,6 +624,7 @@ else()
 		set(ARCAN_DEFINITIONS "")
 		set(ARCAN_NOLWA_DEFINITIONS "")
 		set(VIDEO_PLATFORM_SOURCES "")
+		set(AUDIO_PLATFORM_SOURCES "")
 		set(INPUT_PLATFORM_SOURCES "")
 
 	# HACK: Force- remove the psep-open from the platform and switch to the open
@@ -661,6 +635,7 @@ else()
 		endif()
 
 		include(${PLATFORM_ROOT}/cmake/CMakeLists.Video)
+		include(${PLATFORM_ROOT}/cmake/CMakeLists.Audio)
 
 		add_executable(arcan_sdl
 			${SOURCES}
@@ -668,6 +643,7 @@ else()
 			${AGP_SOURCES}
 			${PLATFORM_SOURCES}
 			${VIDEO_PLATFORM_SOURCES}
+			${AUDIO_PLATFORM_SOURCES}
 			${PLATFORM_ROOT}/sdl2/event.c
 		)
 		if (MAIN_DEPS)
@@ -683,7 +659,7 @@ else()
 			FRAMESERVER_MODESTRING=\"${FRAMESERVER_MODESTRING}\"
 		)
 		target_link_libraries(arcan_sdl
-			${STDLIB} ${ARCAN_LIBRARIES} ${VIDEO_LIBRARIES} ${OPENAL_LIBRARY}
+			${STDLIB} ${ARCAN_LIBRARIES} ${VIDEO_LIBRARIES} ${AUDIO_LIBRARIES}
 			${AGP_LIBRARIES} arcan_shmif_int
 		)
 		list(APPEND BIN_INSTALL arcan_sdl)
@@ -713,6 +689,7 @@ else()
 			${AGP_SOURCES}
 			${PLATFORM_SOURCES}
 			${VIDEO_PLATFORM_SOURCES}
+			${AUDIO_PLATFORM_SOURCES}
 			${PLATFORM_ROOT}/headless/event.c
 		)
 		if (MAIN_DEPS)
@@ -727,7 +704,7 @@ else()
 			ARCAN_BUILDVERSION=\"${SOURCE_TAG}-${PLATFORM_BUILDTAG}-${CMAKE_SYSTEM_NAME}\"
 		)
 		target_link_libraries(arcan_headless
-			${STDLIB} ${ARCAN_LIBRARIES} ${VIDEO_LIBRARIES} ${OPENAL_LIBRARY}
+			${STDLIB} ${ARCAN_LIBRARIES} ${VIDEO_LIBRARIES} ${AUDIO_LIBRARIES}
 			${AGP_LIBRARIES} arcan_shmif_int
 		)
 		list(APPEND BIN_INSTALL arcan_headless)

--- a/src/engine/arcan_audio.c
+++ b/src/engine/arcan_audio.c
@@ -7,312 +7,13 @@
  * cleaner.
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <string.h>
-#include <strings.h>
-#include <fcntl.h>
-#include <sys/types.h>
-#include <assert.h>
-#include <limits.h>
-#include <inttypes.h>
-#include <pthread.h>
-
-#include <al.h>
-#include <alc.h>
-
-/* Apple++ does not have the extension header in question (of course) so go
- * with lifted definitions and dynamic loading */
-static void (*alc_device_pause_soft)(ALCdevice*);
-static void (*alc_device_resume_soft)(ALCdevice*);
-
-#include "arcan_math.h"
-#include "arcan_general.h"
-#include "arcan_shmif.h"
-#include "arcan_video.h"
-#include "arcan_audio.h"
-#include "arcan_audioint.h"
-#include "arcan_event.h"
-
-struct arcan_acontext {
-/* linked list of audio sources, the number of available sources are platform /
- * hw dependant, ranging between 10-100 or so */
-	arcan_aobj* first;
-	ALCcontext* context;
-	ALCdevice* device;
-
-	bool al_active;
-
-	arcan_aobj_id lastid;
-	float def_gain;
-
-/* limit on amount of simultaneous active sources */
-	ALuint sample_sources[ARCAN_AUDIO_SLIMIT];
-	intptr_t sample_tags[ARCAN_AUDIO_SLIMIT];
-
-	arcan_tickv atick_counter;
-
-	arcan_monafunc_cb globalhook;
-	void* global_hooktag;
-};
-
-static bool _wrap_alError(arcan_aobj*, char*);
-static ssize_t find_bufferind(arcan_aobj* cur, unsigned bufnum);
-
-#ifndef CONST_MAX_ASAMPLESZ
-#define CONST_MAX_ASAMPLESZ 1048756
-#endif
-
-/* context management here is quite different from video (no push / pop / etc.
- * openAL volatility alongside hardware buffering problems etc. make it too
- * much of a hazzle */
-static struct arcan_acontext _current_acontext = {
-	.first = NULL, .context = NULL, .def_gain = 1.0
-};
-static struct arcan_acontext* current_acontext = &_current_acontext;
-
-static arcan_aobj* arcan_audio_getobj(arcan_aobj_id);
-static arcan_errc audio_free(arcan_aobj_id);
-
-static ALuint load_wave(const char* fname){
-	ALuint rv = 0;
-
-	data_source inres = arcan_open_resource(fname);
-	if (inres.fd == BADFD)
-		return rv;
-
-	map_region inmem = arcan_map_resource(&inres, false);
-	if (inmem.ptr == NULL){
-		arcan_release_resource(&inres);
-		return rv;
-	}
-
-/* only accept well-formed headers */
-	if (memcmp(inmem.ptr + 0, "RIFF", 4) != 0 &&
-		(arcan_warning("load_wave() -- missing RIFF header identifier\n"), true))
-		goto cleanup;
-
-	if (memcmp(inmem.ptr + 8, "WAVE", 4) != 0 &&
-		(arcan_warning("load_wave() -- missing WAVE format identifier\n"), true))
-		goto cleanup;
-
-	uint16_t kv = 0x1234;
-	bool le = (*(char*)&kv) == 0x34;
-	if (!le && (arcan_warning(
-		"load_wave(BE) -- big endian swap unimplemented\n"), true))
-	goto cleanup;
-
-/* a. map resource / file as per usual */
-/* b. read header; (RIFX BE, RIFF LE)
- * Endian, Ofs, Name, Size
- * BE        0,  CID,    4
- * LE        4,  CSz,    4 Whole-chunk Size
- * --        8,  Fmt,    4 (WAVE)
- * --- chunk 1 ---
- * BE       12,  CID,    4
- * LE       16,  CSz,    4 (subchunk size)
- * LE       20, AFMt,    2 (PCM: 0x0001)
- * LE       22,  NCh,    2
- * LE       24, SRte,    4
- * LE       28, BRte,    4
- * LE       32, Algn,    2
- * LE       34, Btps,    2
- * --- chunk 2 --- (data)
- * BE       36,  CID,    4
- * LE       40,  CSz,    4
- * LE       44,  data    *
- * 8bit are unsigned, 16bit are 2compl. signed,
- * stereo are planar (rch then lch) */
-	int16_t  fmt;
-	int16_t  nch;
-	uint16_t bits_ps;
-	uint16_t smplrte;
-	int32_t  nofs;
-
-	if (memcmp(inmem.ptr + 12, "fmt ", 4) != 0 &&
-		(arcan_warning("load_wave() -- missing format chuck ID\n"), true))
-		goto cleanup;
-
-	memcpy(&fmt,     inmem.ptr + 20, 2);
-	memcpy(&nch,     inmem.ptr + 22, 2);
-	memcpy(&smplrte, inmem.ptr + 24, 2);
-	memcpy(&bits_ps, inmem.ptr + 34, 2);
-	memcpy(&nofs,    inmem.ptr + 16, 4);
-	nofs += 20;
-
-	if (fmt != 0x001 && (arcan_warning(
-		"load_wave() -- unsupported encoding (%d),only PCM accepted.\n", fmt), true))
-		goto cleanup;
-
-	if (nch != 1 && nch != 2 && (arcan_warning(
-		"load_wave() -- unexpected number of channels (%d).\n", nch), true))
-		goto cleanup;
-
-	if (bits_ps != 8 && bits_ps != 16 && (arcan_warning(
-		"load_wave() -- unsupported bitdepth (%d)\n", bits_ps), true))
-		goto cleanup;
-
-	if (smplrte != 48000 && smplrte != 44100 && smplrte != 22050 && smplrte != 11025)
-		arcan_warning("load_wave() -- unconventional samplerate (%d).\n", smplrte);
-
-	if (memcmp(inmem.ptr + nofs, "data", 4) != 0 &&
-		(arcan_warning("load_wave() -- data chunk not found\n"), true))
-		goto cleanup;
-
-	int32_t nb;
-	memcpy(&nb, inmem.ptr + nofs + 4, 4);
-	if (nb > CONST_MAX_ASAMPLESZ){
-		arcan_warning("load_wave() -- sample exceeds compile time limit "
-			" (CONST_MAX_ASAMPLESZ %d), truncating.\n", CONST_MAX_ASAMPLESZ);
-		nb = CONST_MAX_ASAMPLESZ;
-	}
-
-	if (nb > (inmem.sz - nofs - 4) && (arcan_warning(
-	 "load wave() -- total sample size is larger than the mapped input.\n"), true))
-		goto cleanup;
-
-	int alfmt = 0;
-	off_t ofs = nofs + 8;
-	int32_t innb = nb;
-
-	uint8_t* samplebuf = arcan_alloc_mem(nb,
-		ARCAN_MEM_ABUFFER, 0, ARCAN_MEMALIGN_PAGE);
-
-	if (bits_ps == 8){
-		alfmt = nch == 1 ? AL_FORMAT_MONO8 : AL_FORMAT_STEREO8;
-		memcpy(samplebuf, inmem.ptr + ofs, nb);
-	}
-	else if (bits_ps == 16){
-		alfmt = nch == 1 ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16;
-		int16_t* s16_samplebuf = (int16_t*) samplebuf;
-
-		while( nb > 0){
-			memcpy(s16_samplebuf++, inmem.ptr + ofs, 2);
-			ofs += 2;
-			nb -= 2;
-		}
-	}
-
-	alGenBuffers(1, &rv);
-	alBufferData(rv, alfmt, samplebuf, innb, smplrte);
-	_wrap_alError(NULL, "load_wave(bufferData)");
-	arcan_mem_free(samplebuf);
-
-cleanup:
-	arcan_release_map(inmem);
-	arcan_release_resource(&inres);
-
-	return rv;
-}
-
-static arcan_aobj_id arcan_audio_alloc(arcan_aobj** dst, bool defer)
-{
-	arcan_aobj_id rv = ARCAN_EID;
-	ALuint alid = AL_NONE;
-	if (dst)
-		*dst = NULL;
-
-/* some streaming sources never use their audio buffers,
- * defer until it's actually needed (and possibly passive- collect
- * when not feeding to save on IDs */
-	if (!defer){
-		alGenSources(1, &alid);
-		alSourcef(alid, AL_GAIN, current_acontext->def_gain);
-		_wrap_alError(NULL, "audio_alloc(genSources)");
-		if (alid == AL_NONE)
-			return rv;
-	}
-
-	arcan_aobj* newcell = arcan_alloc_mem(sizeof(arcan_aobj), ARCAN_MEM_ATAG,
-		ARCAN_MEM_BZERO, ARCAN_MEMALIGN_NATURAL);
-
-	newcell->alid = alid;
-	newcell->gain = current_acontext->def_gain;
-
-/* unlikely event of wrap-around */
-	newcell->id = current_acontext->lastid++;
-	if (newcell->id == ARCAN_EID)
-		newcell->id = 1;
-
-	if (dst)
-		*dst = newcell;
-
-	if (current_acontext->first){
-		arcan_aobj* current = current_acontext->first;
-		while(current && current->next)
-			current = current->next;
-
-		current->next = newcell;
-	}
-	else
-		current_acontext->first = newcell;
-
-	return newcell->id;
-}
-
-static arcan_aobj* arcan_audio_getobj(arcan_aobj_id id)
-{
-	arcan_aobj* current = current_acontext->first;
-
-	while (current){
-		if (current->id == id)
-			return current;
-
-		current = current->next;
-	}
-
-	return NULL;
-}
+#include "arcan_hmeta.h"
 
 arcan_errc arcan_audio_alterfeed(arcan_aobj_id id, arcan_afunc_cb cb)
 {
 	arcan_errc rv = ARCAN_ERRC_NO_SUCH_OBJECT;
-	arcan_aobj* obj = arcan_audio_getobj(id);
 
-	if (obj) {
-		if (!cb)
-			rv = ARCAN_ERRC_BAD_ARGUMENT;
-		else {
-			obj->feed = cb;
-			rv = ARCAN_OK;
-		}
-	}
-
-	return rv;
-}
-
-static arcan_errc audio_free(arcan_aobj_id id)
-{
-	arcan_errc rv = ARCAN_ERRC_NO_SUCH_OBJECT;
-	arcan_aobj* current = current_acontext->first;
-	arcan_aobj** owner = &(current_acontext->first);
-
- /* find */
-	while(current && current->id != id){
-		owner = &(current->next);
-		current = current->next;
-	}
-
- /* if found, delink */
-	if (current){
-		*owner = current->next;
-
-		if (current->alid != AL_NONE){
-			alSourceStop(current->alid);
-			alDeleteSources(1, &current->alid);
-
-			if (current->n_streambuf)
-				alDeleteBuffers(current->n_streambuf, current->streambuf);
-
-			_wrap_alError(NULL, "audio_free(DeleteBuffers/sources)");
-		}
-		current->next = (void*) 0xdeadbeef;
-		current->tag = (void*) 0xdeadbeef;
-		current->feed = NULL;
-		arcan_mem_free(current);
-
+	if (platform_audio_alterfeed(id, cb)) {
 		rv = ARCAN_OK;
 	}
 
@@ -323,80 +24,22 @@ arcan_errc arcan_audio_setup(bool nosound)
 {
 	arcan_errc rv = ARCAN_ERRC_NOAUDIO;
 
-/* don't supported repeated calls without shutting down in between */
-	if (current_acontext && !current_acontext->context) {
-		ALCint attrs[] = {
-			ALC_FREQUENCY, ARCAN_SHMIF_SAMPLERATE,
-			0
-		};
+	if (nosound){
+		arcan_warning("arcan_audio_init(nosound)\n");
+	}
 
-/* unfortunately, the pretty poorly thought out alcOpenDevice/alcCreateContext
- * doesn't allow you to create a nosound or debug/testing audio device (or for
- * that matter, enumerate without an extension, seriously..) so to avoid yet
- * another codepath, we'll just set the listenerGain to 0 */
-#ifdef ARCAN_LWA
-		current_acontext->device = alcOpenDevice("arcan");
-#else
-		current_acontext->device = alcOpenDevice(NULL);
-#endif
-		current_acontext->context = alcCreateContext(current_acontext->device, attrs);
-		alcMakeContextCurrent(current_acontext->context);
-
-		if (nosound){
-			arcan_warning("arcan_audio_init(nosound)\n");
-			alListenerf(AL_GAIN, 0.0);
-		}
-
-		if (
-			alcIsExtensionPresent(current_acontext->device, "alcDevicePauseSOFT") &&
-			alcIsExtensionPresent(current_acontext->device, "alcDeviceResumeSOFT"))
-		{
-			alc_device_pause_soft = alcGetProcAddress(
-				current_acontext->device, "alcDevicePauseSOFT");
-			alc_device_resume_soft = alcGetProcAddress(
-				current_acontext->device, "alcDeviceResumeSOFT");
-		}
-
-		current_acontext->al_active = true;
+	if (platform_audio_init(nosound)){
 		rv = ARCAN_OK;
-
-		/* just give a slightly "random" base so that
-		 user scripts don't get locked into hard-coded ids .. */
-		arcan_random((unsigned char*)&current_acontext->lastid, sizeof(arcan_aobj_id));
 	}
 
 	return rv;
 }
 
-/*
- * sample code to show which audio devices are available
- * if the OpenAL subsystem support this extension.
-
-	alcIsExtensionPresent(NULL, (ALubyte*)"ALC_ENUMERATION_EXT") => AL_TRUE,
-	devices = (char *)alcGetString(NULL, ALC_DEVICE_SPECIFIER);
-
-	strlen(deviceList)
-	defdev = (char *)alcGetString(NULL, ALC_DEFAULT_DEVICE_SPECIFIER);
-
-	alcOpenDevice from devices, can be used to alcCreateContext
-	then alcMakeContextCurrent
-	something fails, revert to alcOpenDevice
-*/
-
 arcan_errc arcan_audio_shutdown()
 {
 	arcan_errc rv = ARCAN_OK;
-	ALCcontext* ctx = current_acontext->context;
-	if (!ctx)
-		return rv;
 
-/* there might be more to clean-up here, monitoring /callback buffers/tags */
-
-	alcDestroyContext(ctx);
-	current_acontext->al_active = false;
-	current_acontext->context = NULL;
-	memset(current_acontext->sample_sources,
-		'\0', sizeof(ALuint) * ARCAN_AUDIO_SLIMIT);
+	platform_audio_shutdown();
 
 	return rv;
 }
@@ -404,44 +47,13 @@ arcan_errc arcan_audio_shutdown()
 arcan_errc arcan_audio_play(
 	arcan_aobj_id id, bool gain_override, float gain, intptr_t tag)
 {
-	arcan_aobj* aobj = arcan_audio_getobj(id);
+	arcan_errc rv = ARCAN_ERRC_NO_SUCH_OBJECT;
 
-	if (!aobj)
-		return ARCAN_ERRC_NO_SUCH_OBJECT;
-
-/* for aobj sample, just find a free sample slot (if any) and
- * attach the buffer already part of the aobj */
-	if (aobj->kind == AOBJ_SAMPLE){
-		for (size_t i = 0; i < ARCAN_AUDIO_SLIMIT; i++)
-			if (current_acontext->sample_sources[i] == 0){
-				alGenSources(1, &current_acontext->sample_sources[i]);
-				ALint alid = current_acontext->sample_sources[i];
-				current_acontext->sample_tags[i] = tag;
-				alSourcef(alid, AL_GAIN, gain_override ? gain : aobj->gain);
-				_wrap_alError(aobj,"load_sample(alSource)");
-
-				alSourceQueueBuffers(alid, 1, &aobj->streambuf[0]);
-				_wrap_alError(aobj, "load_sample(alQueue)");
-				alSourcePlay(alid);
-				break;
-			}
-	}
-/* some kind of streaming source, can't play if it is already active */
-	else if (aobj->active == false && aobj->alid != AL_NONE){
-		alSourcePlay(aobj->alid);
-		_wrap_alError(aobj, "play(alSourcePlay)");
-		aobj->active = true;
+	if (platform_audio_play(id, gain_override, gain, tag)) {
+		rv = ARCAN_OK;
 	}
 
-	return ARCAN_OK;
-}
-
-static int16_t float_s16(float val)
-{
-	if (val < 0.0)
-		return -val * -32768.0;
-	else
-		return val * 32767.0;
+	return rv;
 }
 
 arcan_aobj_id arcan_audio_sample_buffer(float* buffer,
@@ -450,167 +62,59 @@ arcan_aobj_id arcan_audio_sample_buffer(float* buffer,
 	if (!buffer || !elems || channels <= 0 || channels > 2 || elems % channels != 0)
 		return ARCAN_EID;
 
-	arcan_aobj* aobj;
-	arcan_aobj_id rid = arcan_audio_alloc(&aobj, true);
-	ALuint id = 0;
-
-	if (rid == ARCAN_EID)
-		return ARCAN_EID;
-
-	alGenBuffers(1, &id);
-	if (!alcIsExtensionPresent(current_acontext->device, "AL_EXT_float32")){
-		int16_t* samplebuf = arcan_alloc_mem(
-			elems * 2, ARCAN_MEM_ABUFFER, 0, ARCAN_MEMALIGN_PAGE);
-
-		for (size_t i = 0; i < elems; i++){
-			samplebuf[i] = float_s16(buffer[i]);
-		}
-
-		alBufferData(id,
-			channels == 1 ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16,
-			(uint8_t*)samplebuf, elems * 2, samplerate
-		);
-		arcan_mem_free(samplebuf);
-	}
-	else {
-		int fmt = alGetEnumValue(
-			channels == 1 ? "AL_FORMAT_MONO_FLOAT32" : "AL_FORMAT_STEREO_FLOAT32");
-		alBufferData(id, fmt, buffer, elems * sizeof(float), samplerate);
-	}
-
-	aobj->kind = AOBJ_SAMPLE;
-	aobj->gain = 1.0;
-	aobj->n_streambuf = 1;
-	aobj->streambuf[0] = id;
-	aobj->used = 1;
-
-	return rid;
+	return platform_audio_sample_buffer(buffer, elems, channels, samplerate, fmt_specifier);
 }
 
 arcan_aobj_id arcan_audio_load_sample(
 	const char* fname, float gain, arcan_errc* err)
 {
-	if (fname == NULL)
-		return ARCAN_EID;
-
-	arcan_aobj* aobj;
-	arcan_aobj_id rid = arcan_audio_alloc(&aobj, true);
-
-	if (rid == ARCAN_EID){
-		if (err) *err = ARCAN_ERRC_OUT_OF_SPACE;
+	if (fname == NULL) {
+		*err = ARCAN_ERRC_BAD_ARGUMENT;
 		return ARCAN_EID;
 	}
 
-	ALuint id = load_wave(fname);
-	if (id == AL_NONE){
-		if (err) *err = ARCAN_ERRC_BAD_RESOURCE;
-		audio_free(id);
-		return ARCAN_EID;
-	}
-
-	aobj->kind = AOBJ_SAMPLE;
-	aobj->gain = gain;
-	aobj->n_streambuf = 1;
-	aobj->streambuf[0] = id;
-	aobj->used = 1;
-
-	if (err) *err = ARCAN_OK;
-
-	return rid;
+	return platform_audio_load_sample(fname, gain, err);
 }
 
 arcan_errc arcan_audio_hookfeed(arcan_aobj_id id, void* tag,
 	arcan_monafunc_cb hookfun, void** oldtag)
 {
-	arcan_aobj* aobj = arcan_audio_getobj(id);
-	if (!aobj)
-		return ARCAN_ERRC_NO_SUCH_OBJECT;
+	arcan_errc rv = ARCAN_ERRC_NO_SUCH_OBJECT;
 
-	if (oldtag)
-		*oldtag = aobj->monitortag ? aobj->monitortag : NULL;
+	if (platform_audio_hookfeed(id, tag, hookfun, oldtag)) {
+		rv = ARCAN_OK;
+	}
 
-	aobj->monitor = hookfun;
-	aobj->monitortag = tag;
-
-	return ARCAN_OK;
+	return rv;
 }
 
 arcan_aobj_id arcan_audio_feed(arcan_afunc_cb feed, void* tag, arcan_errc* errc)
 {
-	arcan_aobj* aobj;
-	arcan_aobj_id rid = arcan_audio_alloc(&aobj, true);
-	if (!aobj){
-		if (errc) *errc = ARCAN_ERRC_OUT_OF_SPACE;
-		return ARCAN_EID;
-	}
-
-/* the id will be allocated when we first get data as there
- * is a limit to how many streaming / mixed sources we can support */
-	aobj->alid = AL_NONE;
-	aobj->streaming = true;
-	aobj->tag = tag;
-	aobj->n_streambuf = ARCAN_ASTREAMBUF_LIMIT;
-	aobj->feed = feed;
-	aobj->gain = 1.0;
-	aobj->kind = AOBJ_STREAM;
-
-	if (errc) *errc = ARCAN_OK;
-	return rid;
+	return platform_audio_feed(feed, tag, errc);
 }
 
 /* Another workaround to the many "fine" problems experienced with OpenAL .. */
 arcan_errc arcan_audio_rebuild(arcan_aobj_id id)
 {
-	arcan_aobj* aobj = arcan_audio_getobj(id);
-	arcan_errc rv = ARCAN_ERRC_NO_SUCH_OBJECT;
-	if (!aobj || aobj->alid == AL_NONE)
-		return ARCAN_ERRC_NO_SUCH_OBJECT;
+        arcan_errc rv = ARCAN_ERRC_NO_SUCH_OBJECT;
 
-	alSourceStop(aobj->alid);
-	_wrap_alError(NULL, "audio_rebuild(stop)");
+        if (platform_audio_rebuild(id)){
+                rv = ARCAN_OK;
+        }
 
-	int n;
-	while(alGetSourcei(aobj->alid, AL_BUFFERS_PROCESSED, &n), n > 0){
-		unsigned buffer = 0;
-		alSourceUnqueueBuffers(aobj->alid, 1, &buffer);
-		int bufferind = find_bufferind(aobj, buffer);
-		if (bufferind >= 0){
-			aobj->streambufmask[bufferind] = false;
-			aobj->used--;
-		}
-	}
-
-	alDeleteSources(1, &aobj->alid);
-	alGenSources(1, &aobj->alid);
-	alSourcef(aobj->alid, AL_GAIN, aobj->gain);
-
-	_wrap_alError(NULL, "audio_rebuild(recreate)");
-
-	return ARCAN_OK;
+	return rv;
 }
 
 enum aobj_kind arcan_audio_kind(arcan_aobj_id id)
 {
-	arcan_aobj* aobj = arcan_audio_getobj(id);
-	return aobj ? aobj->kind : AOBJ_INVALID;
+	return platform_audio_kind(id);
 }
 
 arcan_errc arcan_audio_suspend()
 {
 	arcan_errc rv = ARCAN_ERRC_BAD_ARGUMENT;
 
-	arcan_aobj* current = current_acontext->first;
-
-	while (current) {
-		if (current->id != AL_NONE)
-			arcan_audio_pause(current->id);
-
-		current = current->next;
-	}
-
-	current_acontext->al_active = false;
-	if (alc_device_pause_soft)
-		alc_device_pause_soft(current_acontext->device);
+	platform_audio_suspend();
 
 	rv = ARCAN_OK;
 
@@ -620,18 +124,8 @@ arcan_errc arcan_audio_suspend()
 arcan_errc arcan_audio_resume()
 {
 	arcan_errc rv = ARCAN_ERRC_BAD_ARGUMENT;
-	arcan_aobj* current = current_acontext->first;
 
-	if (alc_device_resume_soft)
-		alc_device_resume_soft(current_acontext->device);
-
-	while (current) {
-		if (current->id != AL_NONE)
-			arcan_audio_play(current->id, false, 1.0, -2);
-		current = current->next;
-	}
-
-	current_acontext->al_active = true;
+	platform_audio_resume();
 
 	rv = ARCAN_OK;
 
@@ -640,19 +134,20 @@ arcan_errc arcan_audio_resume()
 
 arcan_errc arcan_audio_pause(arcan_aobj_id id)
 {
-	arcan_aobj* dobj = arcan_audio_getobj(id);
 	arcan_errc rv = ARCAN_ERRC_NO_SUCH_OBJECT;
 
-	if (dobj && dobj->alid != AL_NONE) {
-/*
- * int processed;
- * alGetSourcei(dobj->alid, AL_BUFFERS_PROCESSED, &processed);
- * alSourceUnqueueBuffers(dobj->alid, 1, (unsigned int*) &processed);
- * dobj->used -= processed;
- */
-		alSourceStop(dobj->alid);
-		_wrap_alError(dobj, "audio_pause(get/unqueue/stop)");
-		dobj->active = false;
+	if (platform_audio_pause(id)) {
+		rv = ARCAN_OK;
+	}
+
+	return rv;
+}
+
+arcan_errc arcan_audio_rewind(arcan_aobj_id id)
+{
+	arcan_errc rv = ARCAN_ERRC_NO_SUCH_OBJECT;
+
+	if (platform_audio_rewind(id)) {
 		rv = ARCAN_OK;
 	}
 
@@ -661,277 +156,46 @@ arcan_errc arcan_audio_pause(arcan_aobj_id id)
 
 arcan_errc arcan_audio_stop(arcan_aobj_id id)
 {
-	arcan_aobj* dobj = arcan_audio_getobj(id);
-	if (!dobj)
-		return ARCAN_ERRC_NO_SUCH_OBJECT;
+	arcan_errc rv = ARCAN_ERRC_NO_SUCH_OBJECT;
 
-	dobj->kind = AOBJ_INVALID;
-	dobj->feed = NULL;
-
-	audio_free(id);
-
-	arcan_event newevent = {
-		.category = EVENT_AUDIO,
-		.aud.kind = EVENT_AUDIO_OBJECT_GONE,
-		.aud.source = id
-	};
-
-	arcan_event_enqueue(arcan_event_defaultctx(), &newevent);
-	return ARCAN_OK;
-}
-
-static inline void reset_chain(arcan_aobj* dobj)
-{
-	struct arcan_achain* current = dobj->transform;
-	struct arcan_achain* next;
-
-	while (current) {
-		next = current->next;
-		arcan_mem_free(current);
-		current = next;
+	if (platform_audio_stop(id)) {
+		rv = ARCAN_OK;
 	}
 
-	dobj->transform = NULL;
+	return rv;
 }
 
 arcan_errc arcan_audio_getgain(arcan_aobj_id id, float* gain)
 {
-	if (id == ARCAN_EID){
-		if (gain)
-			*gain = current_acontext->def_gain;
-		return ARCAN_OK;
+	arcan_errc rv = ARCAN_ERRC_NO_SUCH_OBJECT;
+
+	if (platform_audio_getgain(id, gain)) {
+		rv = ARCAN_OK;
 	}
 
-	arcan_aobj* dobj = arcan_audio_getobj(id);
-
-	if (!dobj)
-		return ARCAN_ERRC_NO_SUCH_OBJECT;
-
-	if (gain)
-		*gain = dobj->gain;
-
-	return ARCAN_OK;
+	return rv;
 }
 
 arcan_errc arcan_audio_setgain(arcan_aobj_id id, float gain, uint16_t time)
 {
-	if (id == ARCAN_EID){
-		current_acontext->def_gain = gain;
-		return ARCAN_OK;
+	arcan_errc rv = ARCAN_ERRC_NO_SUCH_OBJECT;
+
+	if (platform_audio_setgain(id, gain, time)) {
+		rv = ARCAN_OK;
 	}
 
-	arcan_aobj* dobj = arcan_audio_getobj(id);
-
-	if (!dobj)
-		return ARCAN_ERRC_NO_SUCH_OBJECT;
-
-/* immediately */
-	if (time == 0){
-		reset_chain(dobj);
-		dobj->gain = gain;
-
-		if (dobj->gproxy)
-			dobj->gproxy(dobj->gain, dobj->tag);
-		else if (dobj->alid){
-			alSourcef(dobj->alid, AL_GAIN, gain);
-			_wrap_alError(dobj, "audio_setgain(getSource/source)");
-		}
-		else
-			;
-	}
-	else{
-		struct arcan_achain** dptr = &dobj->transform;
-
-		while(*dptr){
-			dptr = &(*dptr)->next;
-		}
-
-		*dptr = arcan_alloc_mem(sizeof(struct arcan_achain),
-			ARCAN_MEM_ATAG, 0, ARCAN_MEMALIGN_NATURAL);
-
-		(*dptr)->next = NULL;
-		(*dptr)->t_gain = time;
-		(*dptr)->d_gain = gain;
-	}
-
-	return ARCAN_OK;
+	return rv;
 }
 
-static ssize_t find_bufferind(arcan_aobj* cur, unsigned bufnum){
-	for (size_t i = 0; i < cur->n_streambuf; i++){
-		if (cur->streambuf[i] == bufnum)
-			return i;
-	}
-
-	return -1;
-}
-
-static ssize_t find_freebufferind(arcan_aobj* cur, bool tag){
-	for (size_t i = 0; i < cur->n_streambuf; i++){
-		if (cur->streambufmask[i] == false){
-			if (tag){
-				cur->used++;
-				cur->streambufmask[i] = true;
-			}
-
-			return i;
-		}
-	}
-
-	return -1;
-}
-
-void arcan_audio_buffer(arcan_aobj* aobj, ssize_t buffer, void* audbuf,
+void arcan_audio_buffer(void* aobj, ssize_t buffer, void* audbuf,
 	size_t abufs, unsigned int channels, unsigned int samplerate, void* tag)
 {
-/*
- * even if the AL subsystem should fail, our monitors and globalhook
- * can still work (so record, streaming etc. doesn't cascade)
- */
-	if (aobj->monitor)
-		aobj->monitor(aobj->id, audbuf, abufs, channels,
-			samplerate, aobj->monitortag);
-
-	if (current_acontext->globalhook)
-		current_acontext->globalhook(aobj->id, audbuf, abufs, channels,
-			samplerate, current_acontext->global_hooktag);
-
-/*
- * the audio system can bounce back in the case of many allocations
- * exceeding what can be mixed internally, through the _tick mechanism
- * keeping track of which sources that are actively in use and freeing
- * up those that havn't seen any use for a while.
- */
-	if (aobj->alid == AL_NONE){
-		alGenSources(1, &aobj->alid);
-		alGenBuffers(aobj->n_streambuf, aobj->streambuf);
-		alSourcef(aobj->alid, AL_GAIN, aobj->gain);
-
-		alSourceQueueBuffers(aobj->alid, 1, &aobj->streambuf[0]);
-		aobj->streambufmask[0] = true;
-		aobj->used++;
-		alSourcePlay(aobj->alid);
-
-	_wrap_alError(NULL, "audio_feed(genBuffers)");
-	}
-	else if (aobj->gproxy == false){
-		aobj->last_used = current_acontext->atick_counter;
-		alBufferData(buffer, channels == 2 ? AL_FORMAT_STEREO16 :
-			AL_FORMAT_MONO16, audbuf, abufs, samplerate);
-	}
-}
-
-int arcan_audio_findstreambufslot(arcan_aobj_id id)
-{
-	arcan_aobj* aobj = arcan_audio_getobj(id);
-	return aobj ? find_freebufferind(aobj, true) : -1;
-}
-
-static void astream_refill(arcan_aobj* current)
-{
-	arcan_event newevent = {
-		.category = EVENT_AUDIO,
-		.aud.kind = EVENT_AUDIO_PLAYBACK_FINISHED
-	};
-	ALenum state = 0;
-	ALint processed = 0;
-
-	if (current->alid == AL_NONE && current->feed){
-		current->feed(current, current->alid, 0, false, current->tag);
-		return;
-	}
-
-/* stopped or not, the process is the same,
- * dequeue and requeue as many buffers as possible */
-	alGetSourcei(current->alid, AL_SOURCE_STATE, &state);
-	alGetSourcei(current->alid, AL_BUFFERS_PROCESSED, &processed);
-/* make sure to replace each one that finished with the next one */
-
-	for (size_t i = 0; i < processed; i++){
-		unsigned buffer = 1;
-		alSourceUnqueueBuffers(current->alid, 1, &buffer);
-		ssize_t bufferind = find_bufferind(current, buffer);
-		if (-1 == bufferind){
-			arcan_warning("(audio) unqueue returned unknown buffer, "
-				"processed (%d)\n", (int) bufferind);
-			continue;
-		}
-
-		current->streambufmask[bufferind] = false;
-
-		_wrap_alError(current, "audio_refill(refill:dequeue)");
-		current->used--;
-
-/* as soon as we've used a buffer, try to refill it.
- * for streaming source etc. try with a callback.
- * Some frameserver modes will do this as a push rather than pull however. */
-		if (current->feed){
-			arcan_errc rv = current->feed(current, current->alid,
-				buffer, i < processed - 1, current->tag);
-			_wrap_alError(current, "audio_refill(refill:buffer)");
-
-			if (rv == ARCAN_OK){
-				alSourceQueueBuffers(current->alid, 1, &buffer);
-				current->streambufmask[bufferind] = true;
-				_wrap_alError(current, "audio_refill(refill:queue)");
-				current->used++;
-			}
-			else if (rv == ARCAN_ERRC_NOTREADY)
-				goto playback;
-			else
-				goto cleanup;
-		}
-	}
-
-/* if we're totally empty, try to fill all buffers,
- * if feed fails for the first one, it's over */
-	if (current->used < 0)
-		arcan_warning("arcan_audio(), astream_refill: inconsistency with"
-			"	internal vs openAL buffers.\n");
-
-	if (current->used < current->n_streambuf && current->feed){
-		size_t lim = sizeof(current->streambuf) / sizeof(current->streambuf[0]);
-		for (size_t i = current->used; i < lim; i++){
-			int ind = find_freebufferind(current, false);
-			if (-1 == ind)
-				break;
-
-			arcan_errc rv = current->feed(current, current->alid,
-				current->streambuf[ind], find_freebufferind(
-				current, false) != -1, current->tag
-			);
-
-			if (rv == ARCAN_OK){
-				alSourceQueueBuffers(current->alid, 1, &current->streambuf[ind]);
-				current->streambufmask[ind] = true;
-				current->used++;
-			}
-			else if (rv == ARCAN_ERRC_NOTREADY)
-				goto playback;
-			else
-				goto cleanup;
-		}
-	}
-
-playback:
-	if (current->used && state != AL_PLAYING){
-		alSourcePlay(current->alid);
-		_wrap_alError(current, "audio_restart(astream_refill)");
-	}
-	return;
-
-cleanup:
-/* enqueue direct into drain, this might invoke audio callback on the scripting
- * side in order to immediately chain the playback of another sample */
-	newevent.aud.source = current->id;
-	arcan_event_denqueue(arcan_event_defaultctx(), &newevent);
+	platform_audio_buffer(aobj, buffer, audbuf, abufs, channels, samplerate, tag);
 }
 
 void arcan_aid_refresh(arcan_aobj_id aid)
 {
-	struct arcan_aobj* obj = arcan_audio_getobj(aid);
-	if (obj)
-		astream_refill(obj);
+	platform_audio_aid_refresh(aid);
 }
 
 char** arcan_audio_capturelist()
@@ -950,307 +214,27 @@ char** arcan_audio_capturelist()
 		arcan_mem_free(capturelist);
 	}
 
-/* convert from ALs list format to NULL terminated array of strings */
-	const ALchar* list = alcGetString(NULL, ALC_CAPTURE_DEVICE_SPECIFIER);
-	const ALchar* base = list;
+	platform_audio_capturelist(capturelist);
 
-	int elemc = 0;
-
-	while (*list) {
-		size_t len = strlen(list);
-		if (len)
-			elemc++;
-
-		list += len + 1;
-	};
-
-	capturelist = arcan_alloc_mem(sizeof(char*) * (elemc + 1),
-		ARCAN_MEM_STRINGBUF, 0, ARCAN_MEMALIGN_NATURAL);
-
-	elemc = 0;
-
-	list = base;
-	while (*list){
-		size_t len = strlen(list);
-		if (len){
-			capturelist[elemc] = strdup(list);
-			elemc++;
-		}
-
-		list += len + 1;
-	}
-
-	capturelist[elemc] = NULL;
 	return capturelist;
-}
-
-/* default feed function for capture devices,
- * it just maps to the buffer refill/capture used elsewhere,
- * then it's up to the monitoring function of the recording
- * frameserver to do the mixing */
-static arcan_errc capturefeed(arcan_aobj* aobj, arcan_aobj_id id,
-	ssize_t buffer, bool cont, void* tag)
-{
-	if (buffer < 0)
-		return ARCAN_ERRC_NOTREADY;
-
-/* though a single capture buffer is shared, we don't want it allocated
- * statically as some AL implementations behaved incorrectly and overflowed
- * into other members making it more difficult to track down than necessary */
-	static int16_t* capturebuf;
-
-	if (!capturebuf)
-		capturebuf = arcan_alloc_mem(1024 * 4, ARCAN_MEM_ABUFFER,
-			ARCAN_MEM_SENSITIVE, ARCAN_MEMALIGN_PAGE);
-
-	ALCint sample;
-	ALCdevice* dev = (ALCdevice*) tag;
-
-	alcGetIntegerv(dev, ALC_CAPTURE_SAMPLES, (ALCsizei)sizeof(ALint), &sample);
-	sample = sample > 1024 ? 1024 : sample;
-
-	if (sample <= 0)
-		return ARCAN_ERRC_NOTREADY;
-
-	alcCaptureSamples(dev, (ALCvoid *)capturebuf, sample);
-
-	if (aobj->monitor)
-		aobj->monitor(aobj->id, (uint8_t*) capturebuf, sample << 2,
-			ARCAN_SHMIF_ACHANNELS, ARCAN_SHMIF_SAMPLERATE, aobj->monitortag);
-
-	if (current_acontext->globalhook)
-		current_acontext->globalhook(aobj->id, (uint8_t*) capturebuf,
-			sample << 2, ARCAN_SHMIF_ACHANNELS, ARCAN_SHMIF_SAMPLERATE,
-			current_acontext->global_hooktag
-		);
-
-	return ARCAN_OK;
 }
 
 arcan_aobj_id arcan_audio_capturefeed(const char* dev)
 {
-	arcan_aobj* dstobj = NULL;
-	ALCdevice* capture = alcCaptureOpenDevice(dev,
-		ARCAN_SHMIF_SAMPLERATE, AL_FORMAT_STEREO16, 65536);
-	arcan_audio_alloc(&dstobj, false);
-
-/* we let OpenAL maintain the capture buffer, we flush it like other feeds
- * and resend it back into the playback chain, so that monitoring etc.
- * gets reused */
-	if (_wrap_alError(dstobj, "capture-device") && dstobj){
-		dstobj->streaming = true;
-		dstobj->gain = 1.0;
-		dstobj->kind = AOBJ_CAPTUREFEED;
-		dstobj->n_streambuf = ARCAN_ASTREAMBUF_LIMIT;
-		dstobj->feed = capturefeed;
-		dstobj->tag = capture;
-
-		alGenBuffers(dstobj->n_streambuf, dstobj->streambuf);
-		alcCaptureStart(capture);
-		return dstobj->id;
-	}
-	else{
-		arcan_warning("arcan_audio_capturefeed() - could get audio lock\n");
-		if (capture){
-			alcCaptureStop(capture);
-			alcCaptureCloseDevice(capture);
-		}
-
-		if (dstobj)
-			audio_free(dstobj->id);
-	}
-
-	return ARCAN_EID;
+	return platform_audio_capturefeed(dev);
 }
 
 size_t arcan_audio_refresh()
 {
-	if (!current_acontext->context || !current_acontext->al_active)
-		return 0;
-
-	arcan_aobj* current = current_acontext->first;
-	size_t rv = 0;
-
-	while(current){
-		if (
-			current->kind == AOBJ_STREAM      ||
-			current->kind == AOBJ_FRAMESTREAM ||
-			current->kind == AOBJ_CAPTUREFEED
-		)
-			astream_refill(current);
-
-		_wrap_alError(current, "audio_refresh()");
-		if (current->used)
-			rv++;
-
-		current = current->next;
-	}
-
-	return rv;
-}
-
-static inline bool step_transform(arcan_aobj* obj)
-{
-	if (obj->transform == NULL)
-		return false;
-
-/* OpenAL maps dB to linear */
-	obj->gain += (obj->transform->d_gain - obj->gain) /
-		(float) obj->transform->t_gain;
-
-	obj->transform->t_gain--;
-	if (obj->transform->t_gain == 0){
-		obj->gain = obj->transform->d_gain;
-		struct arcan_achain* ct = obj->transform;
-		obj->transform = obj->transform->next;
-		free(ct);
-	}
-
-	return true;
+        return platform_audio_refresh();
 }
 
 void arcan_audio_tick(uint8_t ntt)
 {
-/*
- * scan list of allocated IDs and update buffers for all streaming / cb
- * functions, also make sure our context is the current active one,
- * flush error buffers etc.
- */
-	if (!current_acontext->context || !current_acontext->al_active)
-		return;
-
-	if (alcGetCurrentContext() != current_acontext->context)
-		alcMakeContextCurrent(current_acontext->context);
-
-	arcan_audio_refresh();
-
-/* update time-dependent transformations */
-	while (ntt-- > 0) {
-		arcan_aobj* current = current_acontext->first;
-
-		while (current){
-			if (step_transform(current)){
-				if (current->gproxy)
-					current->gproxy(current->gain, current->tag);
-				else if (current->alid){
-					alSourcef(current->alid, AL_GAIN, current->gain);
-					_wrap_alError(current, "audio_tick(source/gain)");
-				}
-			}
-
-			current = current->next;
-		}
-
-		current_acontext->atick_counter++;
-	}
-
-/* scan all streaming buffers and free up those no-longer needed */
-	for (size_t i = 0; i < ARCAN_AUDIO_SLIMIT; i++)
-	if ( current_acontext->sample_sources[i] > 0) {
-		ALint state;
-		alGetSourcei(current_acontext->sample_sources[i], AL_SOURCE_STATE, &state);
-		if (state != AL_PLAYING){
-			alDeleteSources(1, &current_acontext->sample_sources[i]);
-			current_acontext->sample_sources[i] = 0;
-
-			if (current_acontext->sample_tags[i] != 0){
-				arcan_event_enqueue(arcan_event_defaultctx(),
-				&(struct arcan_event){
-					.category = EVENT_AUDIO,
-					.aud.kind = EVENT_AUDIO_PLAYBACK_FINISHED,
-					.aud.otag = current_acontext->sample_tags[i]
-				});
-				current_acontext->sample_tags[i] = 0;
-			}
-		}
-	}
+	platform_audio_tick(ntt);
 }
 
-/*
- * very inefficient, but the set of IDs to delete is reasonably small
- */
 void arcan_audio_purge(arcan_aobj_id* ids, size_t nids)
 {
-	arcan_aobj* current = _current_acontext.first;
-	arcan_aobj** previous = &_current_acontext.first;
-
-	while(current){
-		bool match = false;
-
-		for (size_t i = 0; i < nids; i++){
-			if (ids[i] == current->id){
-				match = true;
-				break;
-			}
-		}
-
-		arcan_aobj* next = current->next;
-		if (!match){
-			(*previous) = next;
-			if (current->feed)
-				current->feed(current, current->id, -1, false, current->tag);
-
-			_wrap_alError(current, "audio_stop(stop)");
-
-			if (current->alid != AL_NONE){
-				alSourceStop(current->alid);
-				alDeleteSources(1, &current->alid);
-
-				if (current->n_streambuf)
-					alDeleteBuffers(current->n_streambuf, current->streambuf);
-			}
-
-			arcan_mem_free(current);
-		}
-		else {
-			previous = &current->next;
-		}
-
-		current = next;
-	}
-}
-
-static bool _wrap_alError(arcan_aobj* obj, char* prefix)
-{
-	ALenum errc = alGetError();
-	arcan_aobj empty = {.id = 0, .alid = 0};
-	if (!obj)
-		obj = &empty;
-
-#ifndef _DEBUG
-	return errc == AL_NO_ERROR;
-#endif
-
-	if (errc != AL_NO_ERROR) {
-		arcan_warning("(openAL): ");
-
-		switch (errc) {
-		case AL_INVALID_NAME:
-			arcan_warning("(%u:%u), %s - bad ID passed to function\n",
-				obj->id, obj->alid, prefix);
-			break;
-		case AL_INVALID_ENUM:
-			arcan_warning("(%u:%u), %s - bad enum value passed to function\n",
-				obj->id, obj->alid, prefix);
-			break;
-		case AL_INVALID_VALUE:
-			arcan_warning("(%u:%u), %s - bad value passed to function\n",
-				obj->id, obj->alid, prefix);
-			break;
-		case AL_INVALID_OPERATION:
-			arcan_warning("(%u:%u), %s - requested operation is not valid\n",
-				obj->id, obj->alid, prefix);
-			break;
-		case AL_OUT_OF_MEMORY:
-			arcan_warning("(%u:%u), %s - OpenAL out of memory\n", obj->id,
-				obj->alid, prefix);
-			break;
-		default:
-			arcan_warning("(%u:%u), %s - undefined error\n", obj->id,
-				obj->alid, prefix);
-		}
-		return false;
-	}
-
-	return true;
+	platform_audio_purge(ids, nids);
 }

--- a/src/engine/arcan_audio.h
+++ b/src/engine/arcan_audio.h
@@ -7,48 +7,7 @@
 #ifndef _HAVE_ARCAN_AUDIO
 #define _HAVE_ARCAN_AUDIO
 
-/*
- * This part of the engine has received notably less attention, We've so- far
- * stuck with fixed format, fixed frequency etc.  Many of the more interesting
- * OpenAL bits (effects) are missing. The entire interface, buffer management
- * and platform abstraction is slated for rework in 0.6.
- */
-
-enum aobj_kind {
-	AOBJ_INVALID,
-	AOBJ_STREAM,
-	AOBJ_SAMPLE,
-	AOBJ_FRAMESTREAM,
-	AOBJ_CAPTUREFEED
-};
-struct arcan_aobj;
-
-/*
- * Request a [buffer] to be filled using buffer_data. Provides a negative
- * value to indicate that the audio object is being destructed. [tag] is a a
- * caller-provided that used when creating the feed.  Expects  ARCAN_OK as
- * result to indicate that the buffer should be queued for playback.
- * if [cont] is set, more buffers will be provided if [ARCAN_OK] is
- * returned. Expects [ARCAN_ERRC_NOTREADY] to indicate that there is no more
- * data to feed. Any other error leads to cleanup / destruction.
- */
-typedef arcan_errc(*arcan_afunc_cb)(struct arcan_aobj* aobj,
-	arcan_aobj_id id, ssize_t buffer, bool cont, void* tag);
-
-/*
- * There is one global hook that can be used to get access to audio
- * data as it is beeing flushed to lower layers, and this is the form
- * of that callback.
- */
-typedef void(*arcan_monafunc_cb)(arcan_aobj_id id, uint8_t* buf,
-	size_t bytes, unsigned channels, unsigned frequency, void* tag);
-
-/*
- * It is possible that the frameserver is a process parasite in another
- * process where we would like to interface audio control anyhow throuh
- * a gain proxy. This callback is used for those purposes.
- */
-typedef arcan_errc(*arcan_again_cb)(float gain, void* tag);
+#include "platform_types.h"
 
 /*
  * Setting nosound enforces a global silence, data will still be buffered

--- a/src/engine/arcan_audioint.h
+++ b/src/engine/arcan_audioint.h
@@ -7,63 +7,12 @@
 #ifndef _HAVE_ARCAN_AUDIOINT
 #define _HAVE_ARCAN_AUDIOINT
 
-#ifndef ARCAN_AUDIO_SLIMIT
-#define ARCAN_AUDIO_SLIMIT 32
-#endif
-
-#define ARCAN_ASTREAMBUF_LIMIT ARCAN_SHMIF_ABUFC_LIM
-
-struct arcan_aobj_cell;
-
-struct arcan_achain {
-	unsigned t_gain;
-	float d_gain;
-
-	struct arcan_achain* next;
-};
-
-typedef struct arcan_aobj {
-/* shared */
-	arcan_aobj_id id;
-	unsigned alid;
-	enum aobj_kind kind;
-	bool active;
-
-	float gain;
-
-	struct arcan_achain* transform;
-
-/* AOBJ proxy only */
-	arcan_again_cb gproxy;
-
-/* AOBJ_STREAM only */
-	bool streaming;
-
-/* AOBJ sample only */
-	uint16_t* samplebuf;
-
-/* openAL Buffering */
-	unsigned char n_streambuf;
-	arcan_tickv last_used;
-
-	unsigned streambuf[ARCAN_ASTREAMBUF_LIMIT];
-	bool streambufmask[ARCAN_ASTREAMBUF_LIMIT];
-
-	short used;
-
-/* global hooks */
-	arcan_afunc_cb feed;
-	arcan_monafunc_cb monitor;
-	void* monitortag, (* tag);
-
-/* stored as linked list */
-	struct arcan_aobj* next;
-} arcan_aobj;
+#include "platform_types.h"
 
 void arcan_aid_refresh(arcan_aobj_id aid);
 
 /* just a wrapper around alBufferData that takes monitors into account */
-void arcan_audio_buffer(arcan_aobj*, ssize_t buffer, void* abuf,
+void arcan_audio_buffer(void* aobj, ssize_t buffer, void* abuf,
 	size_t abuf_sz, unsigned channels, unsigned samplerate, void* tag);
 
 #endif

--- a/src/engine/arcan_frameserver.c
+++ b/src/engine/arcan_frameserver.c
@@ -1300,7 +1300,7 @@ bool arcan_frameserver_setramps(arcan_frameserver* src,
  * buffering works. Hence we ignore queing to the selected buffer, and instead
  * use a populate function to retrieve at most n' buffers that we then fill.
  */
-arcan_errc arcan_frameserver_audioframe_direct(arcan_aobj* aobj,
+arcan_errc arcan_frameserver_audioframe_direct(void* aobj,
 	arcan_aobj_id id, unsigned buffer, bool cont, void* tag)
 {
 	arcan_frameserver* src = (arcan_frameserver*) tag;

--- a/src/engine/arcan_frameserver.h
+++ b/src/engine/arcan_frameserver.h
@@ -433,7 +433,7 @@ bool arcan_frameserver_control_chld(arcan_frameserver* src);
 void arcan_frameserver_avfeedmon(arcan_aobj_id src, uint8_t* buf,
 	size_t buf_sz, unsigned channels, unsigned frequency, void* tag);
 
-arcan_errc arcan_frameserver_audioframe_direct(struct arcan_aobj* aobj,
+arcan_errc arcan_frameserver_audioframe_direct(void* aobj,
 	arcan_aobj_id id, unsigned buffer, bool cont, void* tag);
 
 /*

--- a/src/engine/arcan_main.c
+++ b/src/engine/arcan_main.c
@@ -272,6 +272,7 @@ int MAIN_REDIR(int argc, char* argv[])
  */
 	platform_device_init();
 	platform_video_preinit();
+	platform_audio_preinit();
 	platform_event_preinit();
 	arcan_log_destination(stderr, 0);
 

--- a/src/platform/audio/openal.c
+++ b/src/platform/audio/openal.c
@@ -1,0 +1,1272 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <strings.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <assert.h>
+#include <limits.h>
+#include <inttypes.h>
+#include <pthread.h>
+
+#include <al.h>
+#include <alc.h>
+
+/* Apple++ does not have the extension header in question (of course) so go
+ * with lifted definitions and dynamic loading */
+static void (*alc_device_pause_soft)(ALCdevice*);
+static void (*alc_device_resume_soft)(ALCdevice*);
+
+#include "arcan_math.h"
+#include "arcan_general.h"
+#include "arcan_shmif.h"
+#include "arcan_video.h"
+#include "arcan_audio.h"
+#include "arcan_audioint.h"
+#include "arcan_event.h"
+#include "platform_types.h"
+
+#ifndef CONST_MAX_ASAMPLESZ
+#define CONST_MAX_ASAMPLESZ 1048756
+#endif
+
+#ifndef ARCAN_AUDIO_SLIMIT
+#define ARCAN_AUDIO_SLIMIT 32
+#endif
+
+#define ARCAN_ASTREAMBUF_LIMIT ARCAN_SHMIF_ABUFC_LIM
+
+typedef struct arcan_aobj {
+/* shared */
+	arcan_aobj_id id;
+	unsigned alid;
+	enum aobj_kind kind;
+	bool active;
+
+	float gain;
+
+	struct arcan_achain* transform;
+
+/* AOBJ proxy only */
+	arcan_again_cb gproxy;
+
+/* AOBJ_STREAM only */
+	bool streaming;
+
+/* AOBJ sample only */
+	uint16_t* samplebuf;
+
+/* openAL Buffering */
+	unsigned char n_streambuf;
+	arcan_tickv last_used;
+
+	unsigned streambuf[ARCAN_ASTREAMBUF_LIMIT];
+	bool streambufmask[ARCAN_ASTREAMBUF_LIMIT];
+
+	short used;
+
+/* global hooks */
+	arcan_afunc_cb feed;
+	arcan_monafunc_cb monitor;
+	void* monitortag, (* tag);
+
+/* stored as linked list */
+	struct arcan_aobj* next;
+} arcan_aobj;
+
+struct arcan_achain {
+	unsigned t_gain;
+	float d_gain;
+
+	struct arcan_achain* next;
+};
+
+struct arcan_acontext {
+/* linked list of audio sources, the number of available sources are platform /
+ * hw dependant, ranging between 10-100 or so */
+	arcan_aobj* first;
+	ALCcontext* context;
+	ALCdevice* device;
+
+	bool al_active;
+
+	arcan_aobj_id lastid;
+	float def_gain;
+
+/* limit on amount of simultaneous active sources */
+	ALuint sample_sources[ARCAN_AUDIO_SLIMIT];
+	intptr_t sample_tags[ARCAN_AUDIO_SLIMIT];
+
+	arcan_tickv atick_counter;
+
+	arcan_monafunc_cb globalhook;
+	void* global_hooktag;
+};
+
+/* context management here is quite different from video (no push / pop / etc.
+ * openAL volatility alongside hardware buffering problems etc. make it too
+ * much of a hazzle */
+static struct arcan_acontext _current_acontext = {
+	.first = NULL, .context = NULL, .def_gain = 1.0
+};
+static struct arcan_acontext* current_acontext = &_current_acontext;
+
+static bool _wrap_alError(arcan_aobj* obj, char* prefix)
+{
+	ALenum errc = alGetError();
+	arcan_aobj empty = {.id = 0, .alid = 0};
+	if (!obj)
+		obj = &empty;
+
+#ifndef _DEBUG
+	return errc == AL_NO_ERROR;
+#endif
+
+	if (errc != AL_NO_ERROR) {
+		arcan_warning("(openAL): ");
+
+		switch (errc) {
+		case AL_INVALID_NAME:
+			arcan_warning("(%u:%u), %s - bad ID passed to function\n",
+				obj->id, obj->alid, prefix);
+			break;
+		case AL_INVALID_ENUM:
+			arcan_warning("(%u:%u), %s - bad enum value passed to function\n",
+				obj->id, obj->alid, prefix);
+			break;
+		case AL_INVALID_VALUE:
+			arcan_warning("(%u:%u), %s - bad value passed to function\n",
+				obj->id, obj->alid, prefix);
+			break;
+		case AL_INVALID_OPERATION:
+			arcan_warning("(%u:%u), %s - requested operation is not valid\n",
+				obj->id, obj->alid, prefix);
+			break;
+		case AL_OUT_OF_MEMORY:
+			arcan_warning("(%u:%u), %s - OpenAL out of memory\n", obj->id,
+				obj->alid, prefix);
+			break;
+		default:
+			arcan_warning("(%u:%u), %s - undefined error\n", obj->id,
+				obj->alid, prefix);
+		}
+		return false;
+	}
+
+	return true;
+}
+
+static arcan_aobj_id arcan_audio_alloc(arcan_aobj** dst, bool defer)
+{
+	arcan_aobj_id rv = ARCAN_EID;
+	ALuint alid = AL_NONE;
+	if (dst)
+		*dst = NULL;
+
+/* some streaming sources never use their audio buffers,
+ * defer until it's actually needed (and possibly passive- collect
+ * when not feeding to save on IDs */
+	if (!defer){
+		alGenSources(1, &alid);
+		alSourcef(alid, AL_GAIN, current_acontext->def_gain);
+		_wrap_alError(NULL, "audio_alloc(genSources)");
+		if (alid == AL_NONE)
+			return rv;
+	}
+
+	arcan_aobj* newcell = arcan_alloc_mem(sizeof(arcan_aobj), ARCAN_MEM_ATAG,
+		ARCAN_MEM_BZERO, ARCAN_MEMALIGN_NATURAL);
+
+	newcell->alid = alid;
+	newcell->gain = current_acontext->def_gain;
+
+/* unlikely event of wrap-around */
+	newcell->id = current_acontext->lastid++;
+	if (newcell->id == ARCAN_EID)
+		newcell->id = 1;
+
+	if (dst)
+		*dst = newcell;
+
+	if (current_acontext->first){
+		arcan_aobj* current = current_acontext->first;
+		while(current && current->next)
+			current = current->next;
+
+		current->next = newcell;
+	}
+	else
+		current_acontext->first = newcell;
+
+	return newcell->id;
+}
+
+static arcan_errc arcan_audio_free(arcan_aobj_id id)
+{
+	arcan_errc rv = ARCAN_ERRC_NO_SUCH_OBJECT;
+	arcan_aobj* current = current_acontext->first;
+	arcan_aobj** owner = &(current_acontext->first);
+
+ /* find */
+	while(current && current->id != id){
+		owner = &(current->next);
+		current = current->next;
+	}
+
+ /* if found, delink */
+	if (current){
+		*owner = current->next;
+
+		if (current->alid != AL_NONE){
+			alSourceStop(current->alid);
+			alDeleteSources(1, &current->alid);
+
+			if (current->n_streambuf)
+				alDeleteBuffers(current->n_streambuf, current->streambuf);
+
+			_wrap_alError(NULL, "audio_free(DeleteBuffers/sources)");
+		}
+		current->next = (void*) 0xdeadbeef;
+		current->tag = (void*) 0xdeadbeef;
+		current->feed = NULL;
+		arcan_mem_free(current);
+
+		rv = ARCAN_OK;
+	}
+
+	return rv;
+}
+
+
+static ALuint arcan_load_wave(const char* fname)
+{
+	ALuint rv = 0;
+
+	data_source inres = arcan_open_resource(fname);
+	if (inres.fd == BADFD)
+		return rv;
+
+	map_region inmem = arcan_map_resource(&inres, false);
+	if (inmem.ptr == NULL){
+		arcan_release_resource(&inres);
+		return rv;
+	}
+
+/* only accept well-formed headers */
+	if (memcmp(inmem.ptr + 0, "RIFF", 4) != 0 &&
+		(arcan_warning("load_wave() -- missing RIFF header identifier\n"), true))
+		goto cleanup;
+
+	if (memcmp(inmem.ptr + 8, "WAVE", 4) != 0 &&
+		(arcan_warning("load_wave() -- missing WAVE format identifier\n"), true))
+		goto cleanup;
+
+	uint16_t kv = 0x1234;
+	bool le = (*(char*)&kv) == 0x34;
+	if (!le && (arcan_warning(
+		"load_wave(BE) -- big endian swap unimplemented\n"), true))
+	goto cleanup;
+
+/* a. map resource / file as per usual */
+/* b. read header; (RIFX BE, RIFF LE)
+ * Endian, Ofs, Name, Size
+ * BE        0,  CID,    4
+ * LE        4,  CSz,    4 Whole-chunk Size
+ * --        8,  Fmt,    4 (WAVE)
+ * --- chunk 1 ---
+ * BE       12,  CID,    4
+ * LE       16,  CSz,    4 (subchunk size)
+ * LE       20, AFMt,    2 (PCM: 0x0001)
+ * LE       22,  NCh,    2
+ * LE       24, SRte,    4
+ * LE       28, BRte,    4
+ * LE       32, Algn,    2
+ * LE       34, Btps,    2
+ * --- chunk 2 --- (data)
+ * BE       36,  CID,    4
+ * LE       40,  CSz,    4
+ * LE       44,  data    *
+ * 8bit are unsigned, 16bit are 2compl. signed,
+ * stereo are planar (rch then lch) */
+	int16_t  fmt;
+	int16_t  nch;
+	uint16_t bits_ps;
+	uint16_t smplrte;
+	int32_t  nofs;
+
+	if (memcmp(inmem.ptr + 12, "fmt ", 4) != 0 &&
+		(arcan_warning("load_wave() -- missing format chuck ID\n"), true))
+		goto cleanup;
+
+	memcpy(&fmt,     inmem.ptr + 20, 2);
+	memcpy(&nch,     inmem.ptr + 22, 2);
+	memcpy(&smplrte, inmem.ptr + 24, 2);
+	memcpy(&bits_ps, inmem.ptr + 34, 2);
+	memcpy(&nofs,    inmem.ptr + 16, 4);
+	nofs += 20;
+
+	if (fmt != 0x001 && (arcan_warning(
+		"load_wave() -- unsupported encoding (%d),only PCM accepted.\n", fmt), true))
+		goto cleanup;
+
+	if (nch != 1 && nch != 2 && (arcan_warning(
+		"load_wave() -- unexpected number of channels (%d).\n", nch), true))
+		goto cleanup;
+
+	if (bits_ps != 8 && bits_ps != 16 && (arcan_warning(
+		"load_wave() -- unsupported bitdepth (%d)\n", bits_ps), true))
+		goto cleanup;
+
+	if (smplrte != 48000 && smplrte != 44100 && smplrte != 22050 && smplrte != 11025)
+		arcan_warning("load_wave() -- unconventional samplerate (%d).\n", smplrte);
+
+	if (memcmp(inmem.ptr + nofs, "data", 4) != 0 &&
+		(arcan_warning("load_wave() -- data chunk not found\n"), true))
+		goto cleanup;
+
+	int32_t nb;
+	memcpy(&nb, inmem.ptr + nofs + 4, 4);
+	if (nb > CONST_MAX_ASAMPLESZ){
+		arcan_warning("load_wave() -- sample exceeds compile time limit "
+			" (CONST_MAX_ASAMPLESZ %d), truncating.\n", CONST_MAX_ASAMPLESZ);
+		nb = CONST_MAX_ASAMPLESZ;
+	}
+
+	if (nb > (inmem.sz - nofs - 4) && (arcan_warning(
+	 "load wave() -- total sample size is larger than the mapped input.\n"), true))
+		goto cleanup;
+
+	int alfmt = 0;
+	off_t ofs = nofs + 8;
+	int32_t innb = nb;
+
+	uint8_t* samplebuf = arcan_alloc_mem(nb,
+		ARCAN_MEM_ABUFFER, 0, ARCAN_MEMALIGN_PAGE);
+
+	if (bits_ps == 8){
+		alfmt = nch == 1 ? AL_FORMAT_MONO8 : AL_FORMAT_STEREO8;
+		memcpy(samplebuf, inmem.ptr + ofs, nb);
+	}
+	else if (bits_ps == 16){
+		alfmt = nch == 1 ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16;
+		int16_t* s16_samplebuf = (int16_t*) samplebuf;
+
+		while( nb > 0){
+			memcpy(s16_samplebuf++, inmem.ptr + ofs, 2);
+			ofs += 2;
+			nb -= 2;
+		}
+	}
+
+	alGenBuffers(1, &rv);
+	alBufferData(rv, alfmt, samplebuf, innb, smplrte);
+	_wrap_alError(NULL, "load_wave(bufferData)");
+	arcan_mem_free(samplebuf);
+
+cleanup:
+	arcan_release_map(inmem);
+	arcan_release_resource(&inres);
+
+	return rv;
+}
+
+static arcan_aobj* arcan_audio_getobj(arcan_aobj_id id)
+{
+	arcan_aobj* current = current_acontext->first;
+
+	while (current){
+		if (current->id == id)
+			return current;
+
+		current = current->next;
+	}
+
+	return NULL;
+}
+
+/* default feed function for capture devices,
+ * it just maps to the buffer refill/capture used elsewhere,
+ * then it's up to the monitoring function of the recording
+ * frameserver to do the mixing */
+static arcan_errc capturefeed(void* aobjopaq, arcan_aobj_id id,
+	ssize_t buffer, bool cont, void* tag)
+{
+	arcan_aobj* aobj = aobjopaq;
+
+	if (buffer < 0)
+		return ARCAN_ERRC_NOTREADY;
+
+/* though a single capture buffer is shared, we don't want it allocated
+ * statically as some AL implementations behaved incorrectly and overflowed
+ * into other members making it more difficult to track down than necessary */
+	static int16_t* capturebuf;
+
+	if (!capturebuf)
+		capturebuf = arcan_alloc_mem(1024 * 4, ARCAN_MEM_ABUFFER,
+			ARCAN_MEM_SENSITIVE, ARCAN_MEMALIGN_PAGE);
+
+	ALCint sample;
+	ALCdevice* dev = (ALCdevice*) tag;
+
+	alcGetIntegerv(dev, ALC_CAPTURE_SAMPLES, (ALCsizei)sizeof(ALint), &sample);
+	sample = sample > 1024 ? 1024 : sample;
+
+	if (sample <= 0)
+		return ARCAN_ERRC_NOTREADY;
+
+	alcCaptureSamples(dev, (ALCvoid *)capturebuf, sample);
+
+	if (aobj->monitor)
+		aobj->monitor(aobj->id, (uint8_t*) capturebuf, sample << 2,
+			ARCAN_SHMIF_ACHANNELS, ARCAN_SHMIF_SAMPLERATE, aobj->monitortag);
+
+	if (current_acontext->globalhook)
+		current_acontext->globalhook(aobj->id, (uint8_t*) capturebuf,
+			sample << 2, ARCAN_SHMIF_ACHANNELS, ARCAN_SHMIF_SAMPLERATE,
+			current_acontext->global_hooktag
+		);
+
+	return ARCAN_OK;
+}
+
+static inline void reset_chain(arcan_aobj* dobj)
+{
+	struct arcan_achain* current = dobj->transform;
+	struct arcan_achain* next;
+
+	while (current) {
+		next = current->next;
+		arcan_mem_free(current);
+		current = next;
+	}
+
+	dobj->transform = NULL;
+}
+
+static ssize_t find_bufferind(arcan_aobj* cur, unsigned bufnum)
+{
+	for (size_t i = 0; i < cur->n_streambuf; i++){
+		if (cur->streambuf[i] == bufnum)
+			return i;
+	}
+
+	return -1;
+}
+
+static ssize_t find_freebufferind(arcan_aobj* cur, bool tag)
+{
+	for (size_t i = 0; i < cur->n_streambuf; i++){
+		if (cur->streambufmask[i] == false){
+			if (tag){
+				cur->used++;
+				cur->streambufmask[i] = true;
+			}
+
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+static void astream_refill(arcan_aobj* current)
+{
+	arcan_event newevent = {
+		.category = EVENT_AUDIO,
+		.aud.kind = EVENT_AUDIO_PLAYBACK_FINISHED
+	};
+	ALenum state = 0;
+	ALint processed = 0;
+
+	if (current->alid == AL_NONE && current->feed){
+		current->feed(current, current->alid, 0, false, current->tag);
+		return;
+	}
+
+/* stopped or not, the process is the same,
+ * dequeue and requeue as many buffers as possible */
+	alGetSourcei(current->alid, AL_SOURCE_STATE, &state);
+	alGetSourcei(current->alid, AL_BUFFERS_PROCESSED, &processed);
+/* make sure to replace each one that finished with the next one */
+
+	for (size_t i = 0; i < processed; i++){
+		unsigned buffer = 1;
+		alSourceUnqueueBuffers(current->alid, 1, &buffer);
+		ssize_t bufferind = find_bufferind(current, buffer);
+		if (-1 == bufferind){
+			arcan_warning("(audio) unqueue returned unknown buffer, "
+				"processed (%d)\n", (int) bufferind);
+			continue;
+		}
+
+		current->streambufmask[bufferind] = false;
+
+		_wrap_alError(current, "audio_refill(refill:dequeue)");
+		current->used--;
+
+/* as soon as we've used a buffer, try to refill it.
+ * for streaming source etc. try with a callback.
+ * Some frameserver modes will do this as a push rather than pull however. */
+		if (current->feed){
+			arcan_errc rv = current->feed(current, current->alid,
+				buffer, i < processed - 1, current->tag);
+			_wrap_alError(current, "audio_refill(refill:buffer)");
+
+			if (rv == ARCAN_OK){
+				alSourceQueueBuffers(current->alid, 1, &buffer);
+				current->streambufmask[bufferind] = true;
+				_wrap_alError(current, "audio_refill(refill:queue)");
+				current->used++;
+			}
+			else if (rv == ARCAN_ERRC_NOTREADY)
+				goto playback;
+			else
+				goto cleanup;
+		}
+	}
+
+/* if we're totally empty, try to fill all buffers,
+ * if feed fails for the first one, it's over */
+	if (current->used < 0)
+		arcan_warning("arcan_audio(), astream_refill: inconsistency with"
+			"	internal vs openAL buffers.\n");
+
+	if (current->used < current->n_streambuf && current->feed){
+		size_t lim = sizeof(current->streambuf) / sizeof(current->streambuf[0]);
+		for (size_t i = current->used; i < lim; i++){
+			int ind = find_freebufferind(current, false);
+			if (-1 == ind)
+				break;
+
+			arcan_errc rv = current->feed(current, current->alid,
+				current->streambuf[ind], find_freebufferind(
+				current, false) != -1, current->tag
+			);
+
+			if (rv == ARCAN_OK){
+				alSourceQueueBuffers(current->alid, 1, &current->streambuf[ind]);
+				current->streambufmask[ind] = true;
+				current->used++;
+			}
+			else if (rv == ARCAN_ERRC_NOTREADY)
+				goto playback;
+			else
+				goto cleanup;
+		}
+	}
+
+playback:
+	if (current->used && state != AL_PLAYING){
+		alSourcePlay(current->alid);
+		_wrap_alError(current, "audio_restart(astream_refill)");
+	}
+	return;
+
+cleanup:
+/* enqueue direct into drain, this might invoke audio callback on the scripting
+ * side in order to immediately chain the playback of another sample */
+	newevent.aud.source = current->id;
+	arcan_event_denqueue(arcan_event_defaultctx(), &newevent);
+}
+
+static inline bool step_transform(arcan_aobj* obj)
+{
+	if (obj->transform == NULL)
+		return false;
+
+/* OpenAL maps dB to linear */
+	obj->gain += (obj->transform->d_gain - obj->gain) /
+		(float) obj->transform->t_gain;
+
+	obj->transform->t_gain--;
+	if (obj->transform->t_gain == 0){
+		obj->gain = obj->transform->d_gain;
+		struct arcan_achain* ct = obj->transform;
+		obj->transform = obj->transform->next;
+		free(ct);
+	}
+
+	return true;
+}
+
+static int16_t float_s16(float val)
+{
+	if (val < 0.0)
+		return -val * -32768.0;
+	else
+		return val * 32767.0;
+}
+
+void platform_audio_preinit()
+{
+}
+
+bool platform_audio_init(bool noaudio)
+{
+	bool rv = false;
+
+/* don't supported repeated calls without shutting down in between */
+	if (current_acontext && !current_acontext->context) {
+		ALCint attrs[] = {
+			ALC_FREQUENCY, ARCAN_SHMIF_SAMPLERATE,
+			0
+		};
+
+/* unfortunately, the pretty poorly thought out alcOpenDevice/alcCreateContext
+ * doesn't allow you to create a nosound or debug/testing audio device (or for
+ * that matter, enumerate without an extension, seriously..) so to avoid yet
+ * another codepath, we'll just set the listenerGain to 0 */
+#ifdef ARCAN_LWA
+		current_acontext->device = alcOpenDevice("arcan");
+#else
+		current_acontext->device = alcOpenDevice(NULL);
+#endif
+		current_acontext->context = alcCreateContext(current_acontext->device, attrs);
+		alcMakeContextCurrent(current_acontext->context);
+
+		if (noaudio){
+			alListenerf(AL_GAIN, 0.0);
+		}
+
+		if (
+			alcIsExtensionPresent(current_acontext->device, "alcDevicePauseSOFT") &&
+			alcIsExtensionPresent(current_acontext->device, "alcDeviceResumeSOFT"))
+		{
+			alc_device_pause_soft = alcGetProcAddress(
+				current_acontext->device, "alcDevicePauseSOFT");
+			alc_device_resume_soft = alcGetProcAddress(
+				current_acontext->device, "alcDeviceResumeSOFT");
+		}
+
+		current_acontext->al_active = true;
+		rv = true;
+
+		/* just give a slightly "random" base so that
+		 user scripts don't get locked into hard-coded ids .. */
+		arcan_random((unsigned char*)&current_acontext->lastid, sizeof(arcan_aobj_id));
+	}
+
+	return rv;
+}
+
+void platform_audio_suspend()
+{
+	arcan_aobj* current = current_acontext->first;
+
+	while (current) {
+		if (current->id != AL_NONE)
+			platform_audio_pause(current->id);
+
+		current = current->next;
+	}
+
+	current_acontext->al_active = false;
+	if (alc_device_pause_soft)
+		alc_device_pause_soft(current_acontext->device);
+}
+
+void platform_audio_resume()
+{
+	arcan_aobj* current = current_acontext->first;
+
+	if (alc_device_resume_soft)
+		alc_device_resume_soft(current_acontext->device);
+
+	while (current) {
+		if (current->id != AL_NONE)
+			platform_audio_play(current->id, false, 1.0, -2);
+		current = current->next;
+	}
+
+	current_acontext->al_active = true;
+}
+
+void platform_audio_tick(uint8_t ntt)
+{
+/*
+ * scan list of allocated IDs and update buffers for all streaming / cb
+ * functions, also make sure our context is the current active one,
+ * flush error buffers etc.
+ */
+	if (!current_acontext->context || !current_acontext->al_active)
+		return;
+
+	if (alcGetCurrentContext() != current_acontext->context)
+		alcMakeContextCurrent(current_acontext->context);
+
+	platform_audio_refresh();
+
+/* update time-dependent transformations */
+	while (ntt-- > 0) {
+		arcan_aobj* current = current_acontext->first;
+
+		while (current){
+			if (step_transform(current)){
+				if (current->gproxy)
+					current->gproxy(current->gain, current->tag);
+				else if (current->alid){
+					alSourcef(current->alid, AL_GAIN, current->gain);
+					_wrap_alError(current, "audio_tick(source/gain)");
+				}
+			}
+
+			current = current->next;
+		}
+
+		current_acontext->atick_counter++;
+	}
+
+/* scan all streaming buffers and free up those no-longer needed */
+	for (size_t i = 0; i < ARCAN_AUDIO_SLIMIT; i++)
+	if ( current_acontext->sample_sources[i] > 0) {
+		ALint state;
+		alGetSourcei(current_acontext->sample_sources[i], AL_SOURCE_STATE, &state);
+		if (state != AL_PLAYING){
+			alDeleteSources(1, &current_acontext->sample_sources[i]);
+			current_acontext->sample_sources[i] = 0;
+
+			if (current_acontext->sample_tags[i] != 0){
+				arcan_event_enqueue(arcan_event_defaultctx(),
+				&(struct arcan_event){
+					.category = EVENT_AUDIO,
+					.aud.kind = EVENT_AUDIO_PLAYBACK_FINISHED,
+					.aud.otag = current_acontext->sample_tags[i]
+				});
+				current_acontext->sample_tags[i] = 0;
+			}
+		}
+	}
+}
+
+size_t platform_audio_refresh()
+{
+	if (!current_acontext->context || !current_acontext->al_active)
+		return 0;
+
+	arcan_aobj* current = current_acontext->first;
+	size_t rv = 0;
+
+	while(current){
+		if (
+			current->kind == AOBJ_STREAM      ||
+			current->kind == AOBJ_FRAMESTREAM ||
+			current->kind == AOBJ_CAPTUREFEED
+		)
+			astream_refill(current);
+
+		_wrap_alError(current, "audio_refresh()");
+		if (current->used)
+			rv++;
+
+		current = current->next;
+	}
+
+	return rv;
+}
+
+/*
+ * sample code to show which audio devices are available
+ * if the OpenAL subsystem support this extension.
+
+	alcIsExtensionPresent(NULL, (ALubyte*)"ALC_ENUMERATION_EXT") => AL_TRUE,
+	devices = (char *)alcGetString(NULL, ALC_DEVICE_SPECIFIER);
+
+	strlen(deviceList)
+	defdev = (char *)alcGetString(NULL, ALC_DEFAULT_DEVICE_SPECIFIER);
+
+	alcOpenDevice from devices, can be used to alcCreateContext
+	then alcMakeContextCurrent
+	something fails, revert to alcOpenDevice
+*/
+
+void platform_audio_shutdown()
+{
+	ALCcontext* ctx = current_acontext->context;
+	if (!ctx)
+		return;
+
+/* there might be more to clean-up here, monitoring /callback buffers/tags */
+
+	alcDestroyContext(ctx);
+	current_acontext->al_active = false;
+	current_acontext->context = NULL;
+	memset(current_acontext->sample_sources,
+		'\0', sizeof(ALuint) * ARCAN_AUDIO_SLIMIT);
+}
+
+bool platform_audio_rebuild(arcan_aobj_id id)
+{
+	arcan_aobj* aobj = arcan_audio_getobj(id);
+	arcan_errc rv = ARCAN_ERRC_NO_SUCH_OBJECT;
+	if (!aobj || aobj->alid == AL_NONE)
+		return false;
+
+	alSourceStop(aobj->alid);
+	_wrap_alError(NULL, "audio_rebuild(stop)");
+
+	int n;
+	while(alGetSourcei(aobj->alid, AL_BUFFERS_PROCESSED, &n), n > 0){
+		unsigned buffer = 0;
+		alSourceUnqueueBuffers(aobj->alid, 1, &buffer);
+		int bufferind = find_bufferind(aobj, buffer);
+		if (bufferind >= 0){
+			aobj->streambufmask[bufferind] = false;
+			aobj->used--;
+		}
+	}
+
+	alDeleteSources(1, &aobj->alid);
+	alGenSources(1, &aobj->alid);
+	alSourcef(aobj->alid, AL_GAIN, aobj->gain);
+
+	_wrap_alError(NULL, "audio_rebuild(recreate)");
+
+	return true;
+}
+
+bool platform_audio_hookfeed(arcan_aobj_id id, void* tag, arcan_monafunc_cb hookfun, void** oldtag)
+{
+	arcan_aobj* aobj = arcan_audio_getobj(id);
+	if (!aobj)
+		return false;
+
+	if (oldtag)
+		*oldtag = aobj->monitortag ? aobj->monitortag : NULL;
+
+	aobj->monitor = hookfun;
+	aobj->monitortag = tag;
+
+	return true;
+}
+
+arcan_aobj_id platform_audio_load_sample(
+	const char* fname, float gain, arcan_errc* err)
+{
+	arcan_aobj* aobj;
+	arcan_aobj_id rid = arcan_audio_alloc(&aobj, true);
+
+	if (rid == ARCAN_EID){
+		if (err) *err = ARCAN_ERRC_OUT_OF_SPACE;
+		return ARCAN_EID;
+	}
+
+	ALuint id = arcan_load_wave(fname);
+	if (id == AL_NONE){
+		if (err) *err = ARCAN_ERRC_BAD_RESOURCE;
+		arcan_audio_free(id);
+		return ARCAN_EID;
+	}
+
+	aobj->kind = AOBJ_SAMPLE;
+	aobj->gain = gain;
+	aobj->n_streambuf = 1;
+	aobj->streambuf[0] = id;
+	aobj->used = 1;
+
+	if (err) *err = ARCAN_OK;
+
+	return rid;
+}
+
+arcan_aobj_id platform_audio_sample_buffer(float* buffer, size_t elems, int channels, int samplerate, const char* fmt_specifier)
+{
+	arcan_aobj* aobj;
+	arcan_aobj_id rid = arcan_audio_alloc(&aobj, true);
+	ALuint id = 0;
+
+	if (rid == ARCAN_EID)
+		return ARCAN_EID;
+
+	alGenBuffers(1, &id);
+	if (!alcIsExtensionPresent(current_acontext->device, "AL_EXT_float32")){
+		int16_t* samplebuf = arcan_alloc_mem(
+			elems * 2, ARCAN_MEM_ABUFFER, 0, ARCAN_MEMALIGN_PAGE);
+
+		for (size_t i = 0; i < elems; i++){
+			samplebuf[i] = float_s16(buffer[i]);
+		}
+
+		alBufferData(id,
+			channels == 1 ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16,
+			(uint8_t*)samplebuf, elems * 2, samplerate
+		);
+		arcan_mem_free(samplebuf);
+	}
+	else {
+		int fmt = alGetEnumValue(
+			channels == 1 ? "AL_FORMAT_MONO_FLOAT32" : "AL_FORMAT_STEREO_FLOAT32");
+		alBufferData(id, fmt, buffer, elems * sizeof(float), samplerate);
+	}
+
+	aobj->kind = AOBJ_SAMPLE;
+	aobj->gain = 1.0;
+	aobj->n_streambuf = 1;
+	aobj->streambuf[0] = id;
+	aobj->used = 1;
+
+	return rid;
+}
+
+bool platform_audio_alterfeed(arcan_aobj_id id, arcan_afunc_cb cb)
+{
+	bool rv = false;
+	arcan_aobj* obj = arcan_audio_getobj(id);
+
+	if (obj) {
+		if (!cb)
+			rv = ARCAN_ERRC_BAD_ARGUMENT;
+		else {
+			obj->feed = cb;
+			rv = true;
+		}
+	}
+
+	return rv;
+}
+
+arcan_aobj_id platform_audio_feed(arcan_afunc_cb feed, void* tag, arcan_errc* errc)
+{
+	arcan_aobj* aobj;
+	arcan_aobj_id rid = arcan_audio_alloc(&aobj, true);
+	if (!aobj){
+		if (errc) *errc = ARCAN_ERRC_OUT_OF_SPACE;
+		return ARCAN_EID;
+	}
+
+/* the id will be allocated when we first get data as there
+ * is a limit to how many streaming / mixed sources we can support */
+	aobj->alid = AL_NONE;
+	aobj->streaming = true;
+	aobj->tag = tag;
+	aobj->n_streambuf = ARCAN_ASTREAMBUF_LIMIT;
+	aobj->feed = feed;
+	aobj->gain = 1.0;
+	aobj->kind = AOBJ_STREAM;
+
+	if (errc) *errc = ARCAN_OK;
+	return rid;
+}
+
+enum aobj_kind platform_audio_kind(arcan_aobj_id id)
+{
+	arcan_aobj* aobj = arcan_audio_getobj(id);
+	return aobj ? aobj->kind : AOBJ_INVALID;
+}
+
+bool platform_audio_stop(arcan_aobj_id id)
+{
+	arcan_aobj* dobj = arcan_audio_getobj(id);
+	if (!dobj)
+		return false;
+
+	dobj->kind = AOBJ_INVALID;
+	dobj->feed = NULL;
+
+	arcan_audio_free(id);
+
+	arcan_event newevent = {
+		.category = EVENT_AUDIO,
+		.aud.kind = EVENT_AUDIO_OBJECT_GONE,
+		.aud.source = id
+	};
+
+	arcan_event_enqueue(arcan_event_defaultctx(), &newevent);
+	return true;
+}
+
+bool platform_audio_play(
+	arcan_aobj_id id, bool gain_override, float gain, intptr_t tag)
+{
+	arcan_aobj* aobj = arcan_audio_getobj(id);
+
+	if (!aobj)
+		return false;
+
+/* for aobj sample, just find a free sample slot (if any) and
+ * attach the buffer already part of the aobj */
+	if (aobj->kind == AOBJ_SAMPLE){
+		for (size_t i = 0; i < ARCAN_AUDIO_SLIMIT; i++)
+			if (current_acontext->sample_sources[i] == 0){
+				alGenSources(1, &current_acontext->sample_sources[i]);
+				ALint alid = current_acontext->sample_sources[i];
+				current_acontext->sample_tags[i] = tag;
+				alSourcef(alid, AL_GAIN, gain_override ? gain : aobj->gain);
+				_wrap_alError(aobj,"load_sample(alSource)");
+
+				alSourceQueueBuffers(alid, 1, &aobj->streambuf[0]);
+				_wrap_alError(aobj, "load_sample(alQueue)");
+				alSourcePlay(alid);
+				break;
+			}
+	}
+/* some kind of streaming source, can't play if it is already active */
+	else if (aobj->active == false && aobj->alid != AL_NONE){
+		alSourcePlay(aobj->alid);
+		_wrap_alError(aobj, "play(alSourcePlay)");
+		aobj->active = true;
+	}
+
+	return true;
+}
+
+bool platform_audio_pause(arcan_aobj_id id)
+{
+	arcan_aobj* dobj = arcan_audio_getobj(id);
+	bool rv = false;
+
+	if (dobj && dobj->alid != AL_NONE) {
+/*
+ * int processed;
+ * alGetSourcei(dobj->alid, AL_BUFFERS_PROCESSED, &processed);
+ * alSourceUnqueueBuffers(dobj->alid, 1, (unsigned int*) &processed);
+ * dobj->used -= processed;
+ */
+		alSourceStop(dobj->alid);
+		_wrap_alError(dobj, "audio_pause(get/unqueue/stop)");
+		dobj->active = false;
+		rv = true;
+	}
+
+	return rv;
+}
+
+bool platform_audio_rewind(arcan_aobj_id id)
+{
+	arcan_aobj* aobj = arcan_audio_getobj(id);
+	bool rv = false;
+
+	if (aobj && aobj->alid != AL_NONE) {
+/* TODO Implement OpenAL rewind */
+		rv = true;
+	}
+
+	return rv;
+}
+
+void platform_audio_capturelist(char** capturelist)
+{
+/* convert from ALs list format to NULL terminated array of strings */
+	const ALchar* list = alcGetString(NULL, ALC_CAPTURE_DEVICE_SPECIFIER);
+	const ALchar* base = list;
+
+	int elemc = 0;
+
+	while (*list) {
+		size_t len = strlen(list);
+		if (len)
+			elemc++;
+
+		list += len + 1;
+	};
+
+	capturelist = arcan_alloc_mem(sizeof(char*) * (elemc + 1),
+		ARCAN_MEM_STRINGBUF, 0, ARCAN_MEMALIGN_NATURAL);
+
+	elemc = 0;
+
+	list = base;
+	while (*list){
+		size_t len = strlen(list);
+		if (len){
+			capturelist[elemc] = strdup(list);
+			elemc++;
+		}
+
+		list += len + 1;
+	}
+
+	capturelist[elemc] = NULL;
+}
+
+arcan_aobj_id platform_audio_capturefeed(const char* identifier)
+{
+	arcan_aobj* dstobj = NULL;
+	ALCdevice* capture = alcCaptureOpenDevice(identifier,
+		ARCAN_SHMIF_SAMPLERATE, AL_FORMAT_STEREO16, 65536);
+	arcan_audio_alloc(&dstobj, false);
+
+/* we let OpenAL maintain the capture buffer, we flush it like other feeds
+ * and resend it back into the playback chain, so that monitoring etc.
+ * gets reused */
+	if (_wrap_alError(dstobj, "capture-device") && dstobj){
+		dstobj->streaming = true;
+		dstobj->gain = 1.0;
+		dstobj->kind = AOBJ_CAPTUREFEED;
+		dstobj->n_streambuf = ARCAN_ASTREAMBUF_LIMIT;
+		dstobj->feed = capturefeed;
+		dstobj->tag = capture;
+
+		alGenBuffers(dstobj->n_streambuf, dstobj->streambuf);
+		alcCaptureStart(capture);
+		return dstobj->id;
+	}
+	else{
+		arcan_warning("arcan_audio_capturefeed() - could get audio lock\n");
+		if (capture){
+			alcCaptureStop(capture);
+			alcCaptureCloseDevice(capture);
+		}
+
+		if (dstobj)
+			arcan_audio_free(dstobj->id);
+	}
+
+	return ARCAN_EID;
+}
+
+bool platform_audio_setgain(arcan_aobj_id id, float gain, uint16_t time)
+{
+	if (id == ARCAN_EID){
+		current_acontext->def_gain = gain;
+		return true;
+	}
+
+	arcan_aobj* dobj = arcan_audio_getobj(id);
+
+	if (!dobj)
+		return false;
+
+/* immediately */
+	if (time == 0){
+		reset_chain(dobj);
+		dobj->gain = gain;
+
+		if (dobj->gproxy)
+			dobj->gproxy(dobj->gain, dobj->tag);
+		else if (dobj->alid){
+			alSourcef(dobj->alid, AL_GAIN, gain);
+			_wrap_alError(dobj, "audio_setgain(getSource/source)");
+		}
+		else
+			;
+	}
+	else{
+		struct arcan_achain** dptr = &dobj->transform;
+
+		while(*dptr){
+			dptr = &(*dptr)->next;
+		}
+
+		*dptr = arcan_alloc_mem(sizeof(struct arcan_achain),
+			ARCAN_MEM_ATAG, 0, ARCAN_MEMALIGN_NATURAL);
+
+		(*dptr)->next = NULL;
+		(*dptr)->t_gain = time;
+		(*dptr)->d_gain = gain;
+	}
+
+	return true;
+}
+
+bool platform_audio_getgain(arcan_aobj_id id, float* gain)
+{
+	if (id == ARCAN_EID){
+		if (gain)
+			*gain = current_acontext->def_gain;
+		return true;
+	}
+
+	arcan_aobj* dobj = arcan_audio_getobj(id);
+
+	if (!dobj)
+		return false;
+
+	if (gain)
+		*gain = dobj->gain;
+
+	return true;
+}
+
+void platform_audio_buffer(void* aobjopaq, ssize_t buffer, void* audbuf,
+	size_t abufs, unsigned int channels, unsigned int samplerate, void* tag)
+{
+	arcan_aobj* aobj = aobjopaq;
+/*
+ * even if the AL subsystem should fail, our monitors and globalhook
+ * can still work (so record, streaming etc. doesn't cascade)
+ */
+	if (aobj->monitor)
+		aobj->monitor(aobj->id, audbuf, abufs, channels,
+			samplerate, aobj->monitortag);
+
+	if (current_acontext->globalhook)
+		current_acontext->globalhook(aobj->id, audbuf, abufs, channels,
+			samplerate, current_acontext->global_hooktag);
+
+/*
+ * the audio system can bounce back in the case of many allocations
+ * exceeding what can be mixed internally, through the _tick mechanism
+ * keeping track of which sources that are actively in use and freeing
+ * up those that havn't seen any use for a while.
+ */
+	if (aobj->alid == AL_NONE){
+		alGenSources(1, &aobj->alid);
+		alGenBuffers(aobj->n_streambuf, aobj->streambuf);
+		alSourcef(aobj->alid, AL_GAIN, aobj->gain);
+
+		alSourceQueueBuffers(aobj->alid, 1, &aobj->streambuf[0]);
+		aobj->streambufmask[0] = true;
+		aobj->used++;
+		alSourcePlay(aobj->alid);
+
+	_wrap_alError(NULL, "audio_feed(genBuffers)");
+	}
+	else if (aobj->gproxy == false){
+		aobj->last_used = current_acontext->atick_counter;
+		alBufferData(buffer, channels == 2 ? AL_FORMAT_STEREO16 :
+			AL_FORMAT_MONO16, audbuf, abufs, samplerate);
+	}
+}
+
+void platform_audio_aid_refresh(arcan_aobj_id aid)
+{
+	struct arcan_aobj* obj = arcan_audio_getobj(aid);
+	if (obj)
+		astream_refill(obj);
+}
+
+/*
+ * very inefficient, but the set of IDs to delete is reasonably small
+ */
+void platform_audio_purge(arcan_aobj_id* save, size_t save_count)
+{
+	arcan_aobj* current = _current_acontext.first;
+	arcan_aobj** previous = &_current_acontext.first;
+
+	while(current){
+		bool match = false;
+
+		for (size_t i = 0; i < save_count; i++){
+			if (save[i] == current->id){
+				match = true;
+				break;
+			}
+		}
+
+		arcan_aobj* next = current->next;
+		if (!match){
+			(*previous) = next;
+			if (current->feed)
+				current->feed(current, current->id, -1, false, current->tag);
+
+			_wrap_alError(current, "audio_stop(stop)");
+
+			if (current->alid != AL_NONE){
+				alSourceStop(current->alid);
+				alDeleteSources(1, &current->alid);
+
+				if (current->n_streambuf)
+					alDeleteBuffers(current->n_streambuf, current->streambuf);
+			}
+
+			arcan_mem_free(current);
+		}
+		else {
+			previous = &current->next;
+		}
+
+		current = next;
+	}
+}

--- a/src/platform/audio_platform.h
+++ b/src/platform/audio_platform.h
@@ -1,0 +1,62 @@
+#ifndef HAVE_ARCAN_AUDIOPLATFORM
+#define HAVE_ARCAN_AUDIOPLATFORM
+
+#include "platform_types.h"
+
+void platform_audio_preinit();
+
+bool platform_audio_init(bool nosound);
+
+void platform_audio_suspend();
+
+void platform_audio_resume();
+
+void platform_audio_tick(uint8_t ntt);
+
+size_t platform_audio_refresh();
+
+void platform_audio_shutdown();
+
+bool platform_audio_rebuild(arcan_aobj_id id);
+
+bool platform_audio_hookfeed(
+	arcan_aobj_id id, void* tag, arcan_monafunc_cb hookfun, void** oldtag);
+
+arcan_aobj_id platform_audio_load_sample(
+	const char* fname, float gain, arcan_errc* err);
+
+arcan_aobj_id platform_audio_sample_buffer(float* buffer,
+	size_t elems, int channels, int samplerate, const char* fmt_specifier);
+
+bool platform_audio_alterfeed(arcan_aobj_id id, arcan_afunc_cb cb);
+
+arcan_aobj_id platform_audio_feed(
+	arcan_afunc_cb feed, void* tag, arcan_errc* errc);
+
+enum aobj_kind platform_audio_kind(arcan_aobj_id id);
+
+bool platform_audio_stop(arcan_aobj_id id);
+
+bool platform_audio_play(
+	arcan_aobj_id id, bool gain_override, float gain, intptr_t tag);
+
+bool platform_audio_pause(arcan_aobj_id id);
+
+bool platform_audio_rewind(arcan_aobj_id id);
+
+void platform_audio_capturelist(char** capturelist);
+
+arcan_aobj_id platform_audio_capturefeed(const char* identifier);
+
+bool platform_audio_setgain(arcan_aobj_id id, float gain, uint16_t time);
+
+bool platform_audio_getgain(arcan_aobj_id id, float* cgain);
+
+void platform_audio_buffer(void* aobj, ssize_t buffer, void* audbuf,
+	size_t abufs, unsigned int channels, unsigned int samplerate, void* tag);
+
+void platform_audio_aid_refresh(arcan_aobj_id aid);
+
+void platform_audio_purge(arcan_aobj_id* save, size_t save_count);
+
+#endif

--- a/src/platform/cmake/CMakeLists.Audio
+++ b/src/platform/cmake/CMakeLists.Audio
@@ -1,0 +1,56 @@
+#
+# Expects:
+#  AUDIO_PLATFORM (or FATAL)
+#  PLATFORM_ROOT
+#
+# Defines:
+#  AUDIO_LIBRARIES
+#  AUDIO_PLATFORM_SOURCES
+#
+# Modifies:
+#  INCLUDE_DIRS
+#
+
+# reset if we are included multiple times with different video_platform
+set(AUDIO_LIBRARIES "")
+set(AUDIO_PLATFORM_SOURCES "")
+
+if(AUDIO_PLATFORM STREQUAL "openal")
+	# need the separation here to not confuse openAL here with
+	# the version that we patch into LWA
+	if (EXISTS ${EXTERNAL_SRC_DIR}/git/openal AND STATIC_OPENAL)
+		amsg("${CL_YEL}Building OpenAL static from external/git mirror${CL_RST}")
+		ExternalProject_Add(OpenAL
+			SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/openal
+			BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/openal_static
+			UPDATE_COMMAND ""
+			GIT_REPOSITORY "${EXTERNAL_SRC_DIR}/git/openal"
+			${EXTERNAL_DEFS}
+			${CMAKE_EXTERNAL_DEFS}
+			-DALSOFT_BACKEND_DSOUND=OFF
+			-DALSOFT_BACKEND_MMDEVAPI=OFF
+			-DALSOFT_BACKEND_OPENSL=OFF
+			-DALSOFT_BACKEND_PORTAUDIO=OFF
+			-DALSOFT_BACKEND_SOLARIS=OFF
+			-DALSOFT_BACKEND_SNDIO=OFF
+			-DALSOFT_BACKEND_QSA=OFF
+			-DALSOFT_BACKEND_WAVE=OFF
+			-DALSOFT_BACKEND_WINMM=OFF
+		)
+		set(OPENAL_LIBRARY
+			"${CMAKE_CURRENT_BINARY_DIR}/openal_static/libopenal.a"
+		)
+		set(OPENAL_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/include/AL")
+		list(APPEND MAIN_DEPS OpenAL)
+	else()
+		find_package(OpenAL REQUIRED QUIET)
+	endif()
+
+	list(APPEND INCLUDE_DIRS ${OPENAL_INCLUDE_DIR})
+
+	set(AUDIO_PLATFORM_SOURCES ${PLATFORM_ROOT}/audio/openal.c)
+	list(APPEND AUDIO_LIBRARIES ${OPENAL_LIBRARY})
+else()
+	message(FATAL_ERROR
+"${CLB_WHT}No audio platform defined${CLB_RST}, see -DAUDIO_PLATFORM=xx above${CL_RST}.")
+endif()

--- a/src/platform/cmake/CMakeLists.LWA
+++ b/src/platform/cmake/CMakeLists.LWA
@@ -71,6 +71,7 @@ add_executable(arcan_lwa
 	${AGP_SOURCES}
 	${LWA_PLATFORM}
 	${PLATFORM_ROOT}/arcan/video.c
+	${PLATFORM_ROOT}/audio/openal.c
 )
 
 add_sanitizers(arcan_lwa)

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -15,6 +15,7 @@
 #include "platform_types.h"
 #include "agp_platform.h"
 #include "video_platform.h"
+#include "audio_platform.h"
 #include "fsrv_platform.h"
 #include "os_platform.h"
 #include "event_platform.h"

--- a/src/platform/platform_types.h
+++ b/src/platform/platform_types.h
@@ -10,6 +10,7 @@
 #define BADFD -1
 #endif
 
+#include <stdint.h>
 #include <pthread.h>
 #include <semaphore.h>
 
@@ -19,6 +20,48 @@ typedef pid_t process_handle;
 typedef sem_t* sem_handle;
 typedef int8_t arcan_errc;
 typedef int arcan_aobj_id;
+
+/*
+ * This part of the engine has received notably less attention, We've so- far
+ * stuck with fixed format, fixed frequency etc.  Many of the more interesting
+ * OpenAL bits (effects) are missing. The entire interface, buffer management
+ * and platform abstraction is slated for rework in 0.6.
+ */
+
+enum aobj_kind {
+	AOBJ_INVALID,
+	AOBJ_STREAM,
+	AOBJ_SAMPLE,
+	AOBJ_FRAMESTREAM,
+	AOBJ_CAPTUREFEED
+};
+
+/*
+ * Request a [buffer] to be filled using buffer_data. Provides a negative
+ * value to indicate that the audio object is being destructed. [tag] is a a
+ * caller-provided that used when creating the feed.  Expects  ARCAN_OK as
+ * result to indicate that the buffer should be queued for playback.
+ * if [cont] is set, more buffers will be provided if [ARCAN_OK] is
+ * returned. Expects [ARCAN_ERRC_NOTREADY] to indicate that there is no more
+ * data to feed. Any other error leads to cleanup / destruction.
+ */
+typedef arcan_errc(*arcan_afunc_cb)(
+	void* aobj, arcan_aobj_id id, ssize_t buffer, bool cont, void* tag);
+
+/*
+ * There is one global hook that can be used to get access to audio
+ * data as it is beeing flushed to lower layers, and this is the form
+ * of that callback.
+ */
+typedef void(*arcan_monafunc_cb)(arcan_aobj_id id, uint8_t* buf,
+	size_t bytes, unsigned channels, unsigned frequency, void* tag);
+
+/*
+ * It is possible that the frameserver is a process parasite in another
+ * process where we would like to interface audio control anyhow throuh
+ * a gain proxy. This callback is used for those purposes.
+ */
+typedef arcan_errc(*arcan_again_cb)(float gain, void* tag);
 
 /*
  * We only work with / support one internal pixel representation which should

--- a/src/shmif/arcan_shmif_server.c
+++ b/src/shmif/arcan_shmif_server.c
@@ -15,7 +15,6 @@
  * no reason for the two implementations.
  */
 typedef int shm_handle;
-struct arcan_aobj;
 #include "arcan_math.h"
 #include "arcan_general.h"
 #include "arcan_frameserver.h"


### PR DESCRIPTION
Refactors OpenAL out of engine/arcan_audio.c.

Adds nescessary CMake instructions to support swappable audio platform.

Didn't bring over related `arcan_audio.h` endpoint documentation comments to `platform_audio.h`, cab do it if it seems reasonable.