### PR TITLE
Makes external/git/clone.sh POSIX shell compatible

### DIFF
--- a/external/git/clone.sh
+++ b/external/git/clone.sh
@@ -1,13 +1,21 @@
-#!/bin/bash
+#!/bin/sh
 
 # solution plucked from http://stackoverflow.com/questions/59895
-SOURCE="${BASH_SOURCE[0]}"
+SOURCE="$0"
 while [ -h "$SOURCE" ]; do
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
   SOURCE="$(readlink "$SOURCE")"
-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+  case $SOURCE in
+    "/"*) true ;;
+    *) SOURCE="$DIR/$SOURCE" ;;
+  esac
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+if [ ! -f "$DIR/clone.sh" ] || [ -h "$DIR/clone.sh" ]; then
+  >&2 echo 'Could not resolve source directory, make sure to execute the source file instead of sourcing it'
+  exit 1
+fi
 
 git clone http://luajit.org/git/luajit-2.0.git "$DIR/luajit"
 git clone https://github.com/letoram/openal.git "$DIR/openal"


### PR DESCRIPTION
Makes `clone.sh` posix shell compatible.

As a sideeffect requires the source file to be executed, not sourced, since POSIX shell can not properly detect sourced file location.