### PR TITLE
Improves keyboard key repeat timer reset logic

### DIFF
--- a/data/scripts/builtin/keyboard.lua
+++ b/data/scripts/builtin/keyboard.lua
@@ -572,12 +572,21 @@ symtable.patch = function(tbl, iotbl)
 -- Remember for repeating in .tick(), only the same modifier table will
 -- actually continue the repeats, so holding l until repeat then pressing shift
 -- L will reset the repeat counter.
-	if iotbl.active then
-		tbl.last = iotbl;
-	else
+	if tbl:is_modifier(iotbl) then
 		tbl.last = nil;
+		tbl.counter = tbl.delay;
+	else
+		if iotbl.active then
+			if tbl.last ~= iotbl then
+				tbl.counter = tbl.delay;
+			end
+
+			tbl.last = iotbl;
+		elseif tbl.last and tbl.last.keysym == iotbl.keysym then
+			tbl.last = nil;
+			tbl.counter = tbl.delay;
+		end
 	end
-	tbl.counter = tbl.delay;
 
 -- apply utf8 translation and modify supplied utf8 with keymap
 	if (tbl.keymap) then


### PR DESCRIPTION
Previously key repeat counter reset too often, blurring the difference between `keyrate` and `keydelay`. Also improves repeat logic when holding multiple keys and releasing them in some order.