### PR TITLE
Adds keysym and keysym label lookup functions to keyboard.lua

### DIFF
--- a/data/scripts/builtin/keyboard.lua
+++ b/data/scripts/builtin/keyboard.lua
@@ -292,6 +292,14 @@ local symtable =
 	period = 0
 };
 
+symtable.tolabel = function(keysym)
+	return KEYSYM_LABEL_LUT[keysym]
+end
+
+symtable.tokeysym = function(label)
+	return LABEL_KEYSYM_LUT[label]
+end
+
 symtable.tochar = function(ind)
 	return KEYSYM_ASCII_LUT[ind];
 end


### PR DESCRIPTION
Prior to the keysym LUT refactor the mappings were exposed publicly under the keyboard module itself. After moving LUT to local variables, there is no way to use it in other scripts such as in pipeworld appl. This adds simple functions to look up keysyms and labels.