### PR TITLE
Implements font glyph cache sharing between multiple sources

### DIFF
--- a/src/engine/arcan_ttf.h
+++ b/src/engine/arcan_ttf.h
@@ -43,7 +43,7 @@
 #define _ARCAN_TTF_H
 
 /* The internal structure containing font information */
-typedef struct _TTF_Font TTF_Font;
+typedef struct c_font_ref TTF_Font;
 
 typedef struct {
 	uint8_t r, g, b;


### PR DESCRIPTION
Primarily fonts are cached based on the following properties: font file, font size, horizontal and vertical DPI.

Unfortunately the loaded fonts can be mutated by changing their hinting and style.
Due to these mutations an extra indirection is required for font struct access, so that it would be possible to fork cached font and apply the mutation on the new copy. This ensures that other references to the original font are not affected by local mutation.

Although such indirection and forking considerably increases caching complexity, it comes with benefits such as amortising font style changes in heavily formatted text, which normally would require glyph cache flush on every font style or hinting change.