### PR TITLE
Fixes modifiers type signature in input_key callback

### DIFF
--- a/src/frameserver/terminal/default/arcterm.c
+++ b/src/frameserver/terminal/default/arcterm.c
@@ -612,7 +612,7 @@ static void on_mouse_button(struct tui_context* c,
 }
 
 static void on_key(struct tui_context* c, uint32_t keysym,
-	uint8_t scancode, uint8_t mods, uint16_t subid, void* t)
+	uint8_t scancode, uint16_t mods, uint16_t subid, void* t)
 {
 	trace("on_key(%"PRIu32",%"PRIu8",%"PRIu16")", keysym, scancode, subid);
 	if (term.pipe)

--- a/src/frameserver/terminal/default/st/tui.c
+++ b/src/frameserver/terminal/default/st/tui.c
@@ -267,7 +267,7 @@ static void on_mouse_button(
 }
 
 static void on_key(struct tui_context* c, uint32_t symest,
-	uint8_t scancode, uint8_t mods, uint16_t subid, void* t)
+	uint8_t scancode, uint16_t mods, uint16_t subid, void* t)
 {
 	char *str = NULL;
 	if (mods & TUIM_SHIFT){

--- a/src/shmif/arcan_tui.h
+++ b/src/shmif/arcan_tui.h
@@ -339,7 +339,7 @@ struct tui_cbcfg {
  *
  */
 	void (*input_key)(struct tui_context*, uint32_t symest,
-		uint8_t scancode, uint8_t mods, uint16_t subid, void* tag);
+		uint8_t scancode, uint16_t mods, uint16_t subid, void* tag);
 
 /*
  * other input- that wasn't handled in the other callbacks

--- a/src/shmif/tui/lua/tui_lua.c
+++ b/src/shmif/tui/lua/tui_lua.c
@@ -432,7 +432,7 @@ static void on_mouse_button(struct tui_context* T,
 }
 
 static void on_key(struct tui_context* T, uint32_t xkeysym,
-	uint8_t scancode, uint8_t mods, uint16_t subid, void* t)
+	uint8_t scancode, uint16_t mods, uint16_t subid, void* t)
 {
 	SETUP_HREF("key",);
 		lua_pushnumber(L, subid);

--- a/src/shmif/tui/widgets/bufferwnd.c
+++ b/src/shmif/tui/widgets/bufferwnd.c
@@ -1317,7 +1317,7 @@ static void step_cursor_e(struct tui_context* T, struct bufferwnd_meta* M)
 }
 
 static void on_key_input(struct tui_context* T, uint32_t keysym,
-	uint8_t scancode, uint8_t mods, uint16_t subid, void* tag)
+	uint8_t scancode, uint16_t mods, uint16_t subid, void* tag)
 {
 	struct bufferwnd_meta* M = tag;
 /* might want to provide the label based approach to these as well, UP/DOWN

--- a/src/shmif/tui/widgets/listwnd.c
+++ b/src/shmif/tui/widgets/listwnd.c
@@ -454,7 +454,7 @@ static bool on_label_input(
 }
 
 static void key_input(struct tui_context* T, uint32_t keysym,
-	uint8_t scancode, uint8_t mods, uint16_t subid, void* tag)
+	uint8_t scancode, uint16_t mods, uint16_t subid, void* tag)
 {
 	struct listwnd_meta* M = tag;
 	for (size_t i = 0; i < COUNT_OF(labels); i++){

--- a/src/shmif/tui/widgets/readline.c
+++ b/src/shmif/tui/widgets/readline.c
@@ -868,7 +868,7 @@ static void synch_completion(struct tui_context* T, struct readline_meta* M)
 }
 
 void on_key_input(struct tui_context* T,
-	uint32_t keysym, uint8_t scancode, uint8_t mods, uint16_t subid, void* tag)
+	uint32_t keysym, uint8_t scancode, uint16_t mods, uint16_t subid, void* tag)
 {
 	struct readline_meta* M;
 	if (!validate_context(T, &M))

--- a/tests/frameservers/tui_media/tui_media.c
+++ b/tests/frameservers/tui_media/tui_media.c
@@ -31,7 +31,7 @@ static void fill(struct tui_context* c)
 }
 
 static void on_key(struct tui_context* c, uint32_t xkeysym,
-	uint8_t scancode, uint8_t mods, uint16_t subid, void* t)
+	uint8_t scancode, uint16_t mods, uint16_t subid, void* t)
 {
 	trace("unknown_key(%"PRIu32",%"PRIu8",%"PRIu16")", xkeysym, scancode, subid);
 /* FIXME: move subwindow around */

--- a/tests/frameservers/tui_test/tui_test.c
+++ b/tests/frameservers/tui_test/tui_test.c
@@ -212,7 +212,7 @@ static void on_mouse(struct tui_context* c,
 }
 
 static void on_key(struct tui_context* c, uint32_t xkeysym,
-	uint8_t scancode, uint8_t mods, uint16_t subid, void* t)
+	uint8_t scancode, uint16_t mods, uint16_t subid, void* t)
 {
 	trace("unknown_key(%"PRIu32",%"PRIu8",%"PRIu16")", xkeysym, scancode, subid);
 }

--- a/tests/frameservers/tui_text/tui_test.c
+++ b/tests/frameservers/tui_text/tui_test.c
@@ -84,7 +84,7 @@ static void on_mouse(struct tui_context* c,
 }
 
 static void on_key(struct tui_context* c, uint32_t keysym,
-	uint8_t scancode, uint8_t mods, uint16_t subid, void* t)
+	uint8_t scancode, uint16_t mods, uint16_t subid, void* t)
 {
 	trace("unknown_key(%"PRIu32",%"PRIu8",%"PRIu16")", keysym, scancode, subid);
 	struct data_buffer* T = t;


### PR DESCRIPTION
Internally arcan uses uint16 for representing modifiers bitset, while this callback used to squeeze it into uint8.