### PR TITLE
(a12) fix syntax error introduced by last commit

### DIFF
--- a/src/a12/net/net.c
+++ b/src/a12/net/net.c
@@ -65,6 +65,7 @@ static struct {
 	.outbound_tag = "default",
 	.dircl = {
 		.source_port = 6681
+	},
 	.dirsrv = {
 		.allow_tunnel = true
 	}


### PR DESCRIPTION
Noticed a typo while trying to build