### PR TITLE
alpine build failed on linking

### DIFF
--- a/src/a12/CMakeLists.txt
+++ b/src/a12/CMakeLists.txt
@@ -1,6 +1,7 @@
 pkg_check_modules(FFMPEG QUIET libavcodec libavdevice libavfilter libavformat libavutil libswresample libswscale)
 
 set(LIBRARIES
+	fts
 	pthread
 	arcan_shmif
 	arcan_shmif_server


### PR DESCRIPTION
with ```apk add musl-fts musl-fts-dev``` build failing with

```[ 43%] Linking C executable ../../afsrv_net
/usr/lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: CMakeFiles/arcan-net.dir/dir_supp.c.o: in function `build_appl_pkg':
dir_supp.c:(.text+0x1601): undefined reference to `fts_open'
/usr/lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: dir_supp.c:(.text+0x17c1): undefined reference to `fts_read'
/usr/lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: dir_supp.c:(.text+0x1a1e): undefined reference to `fts_read'
/usr/lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: dir_supp.c:(.text+0x1a42): undefined reference to `fts_close'
/usr/lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: dir_supp.c:(.text+0x1b7d): undefined reference to `fts_close'
collect2: error: ld returned 1 exit status
make[3]: *** [a12/net/CMakeFiles/arcan-net.dir/build.make:235: arcan-net] Error 1
make[2]: *** [CMakeFiles/Makefile2:814: a12/net/CMakeFiles/arcan-net.dir/all] Error 2
```

this helps. Didn't try on void tho