### PR TITLE
Fix console appl crash and keyboard input

### DIFF
--- a/data/appl/console/console.lua
+++ b/data/appl/console/console.lua
@@ -433,6 +433,7 @@ function valid_hotkey(input)
 
 -- use falling edge and two different sets of actions based on impact
 	local mods = decode_modifiers(input.modifiers, "_")
+	local key = KEYBOARD.tolabel(input.keysym)
 
 	if not input.active or
 		(mods ~= hotkey_modifier and mods ~= syskey_modifier) then
@@ -441,42 +442,42 @@ function valid_hotkey(input)
 
 	if mods == syskey_modifier then
 -- for handy testing of adoption etc.
-		if input.keysym == KEYBOARD.SYSREQ then
+		if key == "SYSREQ" then
 			system_collapse()
 
-		elseif input.keysym == KEYBOARD.BACKSPACE then
+		elseif key == "BACKSPACE" then
 			return shutdown()
 		end
 
 		return true
 	end
 
-	if input.keysym == KEYBOARD.v then
+	if key == "v" then
 		clipboard_paste(clipboard_last)
 
 -- forcibly destroy the current workspace
-	elseif input.keysym == KEYBOARD.DELETE then
+	elseif key == "DELETE" then
 		if workspaces[ws_index] and workspaces[ws_index].vid then
 			delete_workspace(ws_index)
 		end
 
 -- toggle mute on a specific audio source by querying the current value
 -- and inverting it (1.0 - n)
-	elseif input.keysym == KEYBOARD.m then
+	elseif key == "m" then
 		if workspaces[ws_index] and workspaces[ws_index].aid then
 			local current = audio_gain(workspaces[ws_index].aid, nil)
 			audio_gain(workspaces[ws_index].aid, 1.0 - current)
 		end
 
-	elseif input.keysym == KEYBOARD.l then
+	elseif key == "l" then
 		next_workspace()
 
-	elseif input.keysym == KEYBOARD.h then
+	elseif key == "h" then
 		previous_workspace()
 
 -- covert Fn key to numeric index and switch workspace
-	elseif input.keysym >= KEYBOARD.F1 and input.keysym <= KEYBOARD.F10 then
-		switch_workspace(input.keysym - KEYBOARD.F1 + 1)
+	elseif input.keysym >= KEYBOARD.tokeysym("F1") and input.keysym <= KEYBOARD.tokeysym("F10") then
+		switch_workspace(input.keysym - KEYBOARD.tokeysym("F1") + 1)
 	end
 
 	return true


### PR DESCRIPTION
I've noticed that the console appl was crashing on certain keys, so I looked into it and turns out `input.keysym` is being compared to nonexistent members of the `KEYBOARD` table. Now it's first converted to a label for comparison, except in the `>= F1 and <= F10` case, where the labels are converted to keysyms (should probably store those keysym codes somewhere to avoid repeat calls to `tokeysym`).